### PR TITLE
add test models

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ We always welcome new proposals for variability models that should be included i
 ### Test Resources
 
 The remaining models are available for testing purposes.
+These test models are intended to evaluate parsing capabilities rather than automated analysis. They cover all different constructs occurring in UVL and include both legal and illegal UVL models.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,33 @@
 # Database for Real-World Variability Models in UVL
 
-
 [![DOI](https://zenodo.org/badge/346675134.svg)](https://zenodo.org/badge/latestdoi/346675134)
 
-
-In this repository, we provide a large variety of publicliy available real-world variability models. Each model is provided in the Universal Variability Language format (UVL). The variability models are sorted by (1) the type of the original model (i.e., feature/decision/OVM model) and (2) the domain of the variability model (e.g., automotive or operating systems.
+In this repository, we provide a large variety of publicliy available real-world variability models. Each model is provided in the Universal Variability Language format (UVL). The variability models are sorted by (1) the type of the original model (i.e., feature/decision/OVM model) and (2) the domain of the variability model (e.g., automotive or operating systems).
 
 We always welcome new proposals for variability models that should be included in our dataset. You can just leave us a message or open a pull request to merge your models.
 
 ### Variability Models
-|Variability Model |Original Type |Domain            |Number of Models|Number of Features|Number of Constraints|
-|------------------|--------------|------------------|--------------|----------------|-------------------|
-|Automotive01      |Feature Model |Automotive        |1             |2513            |2833               |
-|Automotive02      |Feature Model |Automotive        |4             |14010–18616     |666–1369           |
-|BusyBox           |Feature Model |Operating System  |36            |439–631         |463–691            |
-|CDL               |Feature Model |Operating System  |116           |1178–1408       |816–956            |
-|BerkeleyDB        |Feature Model |Database          |1             |76              |20                 |
-|Financial Services|Feature Model |Financial Services|10            |557--774        |1001--1148         |
-|KConfig           |Feature Model |Operating System  |5             |96–1580         |14–3455            |
-|Linux-2.6.33.3    |Feature Model |Operating System  |1             |6467            |3545               |
-|BMD               |Decision Model|Software          |1             |28              |0                  |
-|Molding           |Decision Model|Automation        |1             |116             |0                  |
-|DOPLER ASE        |Decision Model|DOPLER            |1             |109             |96                 |
-|DOPLER Tools      |Decision Model|DOPLER            |1             |50              |15                 |
-|Mobile Phone DM   |Decision Model|Devices           |1             |11              |1                  |
-|Online Shop DM    |Decision Model|Website           |1             |13              |4                  |
-|Mobile Phone OVM  |OVM Model     |Devices           |1             |10              |1                  |
-|Online Shop OVM   |OVM Model     |Website           |1             |14              |5                  |
-|RFW               |OVM Model     |Devices           |1             |37              |11                 |
 
+| Variability Model  | Original Type  | Domain             | Number of Models | Number of Features | Number of Constraints |
+| ------------------ | -------------- | ------------------ | ---------------- | ------------------ | --------------------- |
+| Automotive01       | Feature Model  | Automotive         | 1                | 2513               | 2833                  |
+| Automotive02       | Feature Model  | Automotive         | 4                | 14010–18616        | 666–1369              |
+| BusyBox            | Feature Model  | Operating System   | 36               | 439–631            | 463–691               |
+| CDL                | Feature Model  | Operating System   | 116              | 1178–1408          | 816–956               |
+| BerkeleyDB         | Feature Model  | Database           | 1                | 76                 | 20                    |
+| Financial Services | Feature Model  | Financial Services | 10               | 557--774           | 1001--1148            |
+| KConfig            | Feature Model  | Operating System   | 5                | 96–1580            | 14–3455               |
+| Linux-2.6.33.3     | Feature Model  | Operating System   | 1                | 6467               | 3545                  |
+| BMD                | Decision Model | Software           | 1                | 28                 | 0                     |
+| Molding            | Decision Model | Automation         | 1                | 116                | 0                     |
+| DOPLER ASE         | Decision Model | DOPLER             | 1                | 109                | 96                    |
+| DOPLER Tools       | Decision Model | DOPLER             | 1                | 50                 | 15                    |
+| Mobile Phone DM    | Decision Model | Devices            | 1                | 11                 | 1                     |
+| Online Shop DM     | Decision Model | Website            | 1                | 13                 | 4                     |
+| Mobile Phone OVM   | OVM Model      | Devices            | 1                | 10                 | 1                     |
+| Online Shop OVM    | OVM Model      | Website            | 1                | 14                 | 5                     |
+| RFW                | OVM Model      | Devices            | 1                | 37                 | 11                    |
+
+### Test Resources
+
+The remaining models are available for testing purposes.

--- a/test_resources/conversion/conversionHighLevel.uvl
+++ b/test_resources/conversion/conversionHighLevel.uvl
@@ -1,0 +1,8 @@
+features
+            Car
+                or
+                    Engine {Power 150}
+                    Wheels {Type "AllSeason"}
+        constraints
+            Engine.Power > 100
+            Wheels.Type == "AllSeason" or Wheels.Type == "Winter"

--- a/test_resources/parsing/arithmetic_level/aggregate_functions/aggregate.uvl
+++ b/test_resources/parsing/arithmetic_level/aggregate_functions/aggregate.uvl
@@ -1,0 +1,9 @@
+features
+    A {Price 1}
+        optional
+            B {Price 2}
+            C {Price 5}
+
+constraints
+    sum(Price) > 2
+    avg(Price) > 1

--- a/test_resources/parsing/arithmetic_level/aggregate_functions/aggregateFunctions.uvl
+++ b/test_resources/parsing/arithmetic_level/aggregate_functions/aggregateFunctions.uvl
@@ -1,0 +1,9 @@
+features
+    A {Price 2}
+        optional
+            B {Price 2}
+            C {Price 5}
+
+constraints
+    sum(Price) == 7
+    avg(Price) == 3.5

--- a/test_resources/parsing/arithmetic_level/aggregate_functions/lengthAggregation.uvl
+++ b/test_resources/parsing/arithmetic_level/aggregate_functions/lengthAggregation.uvl
@@ -1,0 +1,9 @@
+features
+    A
+        optional
+            String B 
+            String C 
+constraints
+    len(B) == 16
+    len(C) == 16
+    len(B) == len(C)

--- a/test_resources/parsing/arithmetic_level/arithmetic-simpleconstraints.uvl
+++ b/test_resources/parsing/arithmetic_level/arithmetic-simpleconstraints.uvl
@@ -1,0 +1,8 @@
+features
+    A
+        or
+            B {Price 3, Fun 8}
+            C {Price 7, Fun 1}
+constraints
+    B.Price + C.Price < 10
+    B.Price * B.Fun > 20

--- a/test_resources/parsing/arithmetic_level/expressions.uvl
+++ b/test_resources/parsing/arithmetic_level/expressions.uvl
@@ -1,0 +1,30 @@
+features
+    A
+        or
+            B {Price 2, Fun 12}
+            C {Price 7, Fun 6}
+constraints
+    B.Fun + C.Fun - B.Price == 16
+    B.Fun + (C.Fun - B.Price) == 16
+    B.Fun + C.Fun * B.Price == 24
+    B.Fun + (C.Fun * B.Price) == 24
+    B.Fun + C.Fun / B.Price == 15
+    B.Fun + (C.Fun / B.Price) == 15
+    B.Fun - C.Fun + B.Price == 8
+    B.Fun - (C.Fun + B.Price) == 4
+    B.Fun - C.Fun * B.Price == 0
+    B.Fun - (C.Fun * B.Price) == 0
+    B.Fun - C.Fun / B.Price == 9
+    B.Fun - (C.Fun / B.Price) == 9
+    B.Fun * C.Fun / B.Price == 36
+    B.Fun * (C.Fun / B.Price) == 36
+    B.Fun * C.Fun - B.Price == 70
+    B.Fun * (C.Fun - B.Price) == 48
+    B.Fun * C.Fun + B.Price == 74
+    B.Fun * (C.Fun + B.Price) == 96
+    B.Fun / C.Fun * B.Price == 4
+    B.Fun / (C.Fun * B.Price) == 1
+    B.Fun / C.Fun + B.Price == 4
+    B.Fun / (C.Fun + B.Price) == 1.5
+    B.Fun / C.Fun - B.Price == 0
+    B.Fun / (C.Fun - B.Price) == 3

--- a/test_resources/parsing/arithmetic_level/feature-cardinality.uvl
+++ b/test_resources/parsing/arithmetic_level/feature-cardinality.uvl
@@ -1,0 +1,6 @@
+features
+    A cardinality [1..4]
+        alternative
+            B
+            C
+            D

--- a/test_resources/parsing/boolean_level/attributes.uvl
+++ b/test_resources/parsing/boolean_level/attributes.uvl
@@ -1,0 +1,5 @@
+features
+    A
+        optional
+            B {Fun 'yes', Name 'B', Package {Name 'P', Content 'Even more fun'}, Price 5}
+            C {Fun 'maybe', Name 'C'}

--- a/test_resources/parsing/boolean_level/boolean.uvl
+++ b/test_resources/parsing/boolean_level/boolean.uvl
@@ -1,0 +1,17 @@
+features
+    A
+        mandatory
+            B
+                or
+                    C
+                    D
+            E
+                alternative
+                    F
+                    G
+
+constraints
+    A & B
+    C | D
+    E => G
+    A <=> B

--- a/test_resources/parsing/boolean_level/cardinality.uvl
+++ b/test_resources/parsing/boolean_level/cardinality.uvl
@@ -1,0 +1,6 @@
+features
+    A
+        [2..3]
+            B
+            C
+            D

--- a/test_resources/parsing/boolean_level/namespace.uvl
+++ b/test_resources/parsing/boolean_level/namespace.uvl
@@ -1,0 +1,7 @@
+namespace nicenamespace
+
+features
+    A
+        or
+            B
+            C

--- a/test_resources/parsing/complex/bike.uvl
+++ b/test_resources/parsing/complex/bike.uvl
@@ -1,0 +1,26 @@
+features
+    Bike
+        mandatory
+            Brake {Weight 3}
+            String Manufacturer
+            Integer Inch
+        [1..3]
+            Bell {Weight 1}
+            "Training Wheels" cardinality [1..5] {Manufacturer 'Wheelio', Price 5}
+                optional
+                    Blah
+            "Light System"
+                or
+                    Front {Weight 2}
+                    Back {Weight 1.5}
+            Dynamo {Weight 3}
+
+constraints
+    sum(Weight) < 10
+    Inch > 22 => !"Training Wheels"
+    sum(Price) < 10
+    Front | Back => Dynamo
+    "Training Wheels" => (Manufacturer == "Training Wheels".Manufacturer)
+    Inch == 22 => !"Training Wheels"
+
+

--- a/test_resources/parsing/composition/composition_root.uvl
+++ b/test_resources/parsing/composition/composition_root.uvl
@@ -1,0 +1,24 @@
+imports
+	composition_sub1
+
+features
+	Computer
+		optional
+			"RAM-module"
+		mandatory
+			"SATA-Devices"
+				[0..3]
+					HDD
+					SSD
+					"DVD-drive"
+					"Card-reader"
+					"Blu-ray-drive"
+			composition_sub1.CPU
+			PSU {abstract true}
+				alternative
+					strong_PSU
+					weak_PSU
+
+constraints
+	SSD => strong_PSU
+	"DVD-drive" <=> composition_sub1.brand & composition_sub1.fmIntel.feature1 & composition_sub1.composition_sub1_sub2.feature2

--- a/test_resources/parsing/composition/composition_sub1.uvl
+++ b/test_resources/parsing/composition/composition_sub1.uvl
@@ -1,0 +1,20 @@
+imports
+	composition_sub1_sub1 as fmIntel
+	composition_sub1_sub2
+
+features
+	CPU
+		mandatory
+			brand
+				alternative
+					fmIntel.Intel
+					composition_sub1_sub2.AMD
+			architecture
+				alternative
+					Bit64 {bit 64}
+					Bit32 {bit 32}
+
+constraints
+	fmIntel.feature1 & fmIntel.feature2 <=> (Bit64) | !composition_sub1_sub2.feature2
+	Bit64.bit + Bit32.bit > 32
+	fmIntel.feature1.power - fmIntel.feature2.power == 25

--- a/test_resources/parsing/composition/composition_sub1_sub1.uvl
+++ b/test_resources/parsing/composition/composition_sub1_sub1.uvl
@@ -1,0 +1,11 @@
+features
+	Intel
+		mandatory
+			feature1 {power 10}
+			feature2 {power 15}
+				alternative
+					feature3
+					feature4
+
+constraints
+	feature1 & feature2 <=> (feature1 | feature2) & feature4

--- a/test_resources/parsing/composition/composition_sub1_sub2.uvl
+++ b/test_resources/parsing/composition/composition_sub1_sub2.uvl
@@ -1,0 +1,11 @@
+features
+	AMD
+		mandatory
+			feature1
+			feature2
+				alternative
+					feature3
+					feature4
+
+constraints
+	feature1 & feature2 <=> (feature1 | feature2) & feature4

--- a/test_resources/parsing/composition/nested/nested_referenced_sub.uvl
+++ b/test_resources/parsing/composition/nested/nested_referenced_sub.uvl
@@ -1,0 +1,5 @@
+features
+    Nested
+        optional
+            N1
+            N2

--- a/test_resources/parsing/composition/nested/nested_sub.uvl
+++ b/test_resources/parsing/composition/nested/nested_sub.uvl
@@ -1,0 +1,9 @@
+imports
+    nested_referenced_sub as nrs
+
+features
+    Root
+        optional
+            F1
+            F2
+            nrs.Nested

--- a/test_resources/parsing/composition/nested_main.uvl
+++ b/test_resources/parsing/composition/nested_main.uvl
@@ -1,0 +1,7 @@
+imports
+    nested.nested_sub as nesu
+
+features
+    Root
+        optional
+            nesu.Root

--- a/test_resources/parsing/faulty/illegalname.uvl
+++ b/test_resources/parsing/faulty/illegalname.uvl
@@ -1,0 +1,4 @@
+features
+    A
+        mandatory
+            12B

--- a/test_resources/parsing/faulty/missingreference.uvl
+++ b/test_resources/parsing/faulty/missingreference.uvl
@@ -1,0 +1,7 @@
+features
+    A
+        mandatory
+            B
+
+constraints
+    C | D

--- a/test_resources/parsing/faulty/same_feature_names.uvl
+++ b/test_resources/parsing/faulty/same_feature_names.uvl
@@ -1,0 +1,35 @@
+features
+	Penguin
+		optional
+			"Left Wing Item"
+				alternative
+					"Lightsaber"
+						alternative
+							"lightsaber left"
+							"light-staff left"
+					"Flag"
+						alternative
+							"german flag left"
+							"pride flag left"
+					"Staff"
+						alternative
+							"staff left"
+							"spear left"
+							"cross left"
+							"cane left"
+			"Right Wing Item"
+				alternative
+					"Lightsaber"
+						alternative
+							"lightsaber right"
+							"light-staff right"
+					"Flag"
+						alternative
+							"german flag right"
+							"pride flag right"
+					"Staff"
+						alternative
+							"staff right"
+							"spear right"
+							"cross right"
+							"cane right"

--- a/test_resources/parsing/faulty/wrong_attribute_name.uvl
+++ b/test_resources/parsing/faulty/wrong_attribute_name.uvl
@@ -1,0 +1,12 @@
+imports
+  nested."string-attributes-external" as external
+
+features
+    A
+        optional
+            B {Fun 'Yes. This is  a Test', Name 'B // Cxn I do a comment in here?', Package {Name 'P', Content 'Even more fun'}, Price 5}
+            C {Fun 'maybe', Name 'C'}
+            D {Fun 'This is a test with a newline in the string', Name 'D'}
+            external.E
+            F {Fun 'This string external.G See?', Name 'F'}
+            G {Fun 'Another.test.with.multiple.dots', Name 'G'}

--- a/test_resources/parsing/faulty/wrongindent.uvl
+++ b/test_resources/parsing/faulty/wrongindent.uvl
@@ -1,0 +1,4 @@
+features
+    A
+    mandatory
+            B

--- a/test_resources/parsing/generated/fm0.uvl
+++ b/test_resources/parsing/generated/fm0.uvl
@@ -1,0 +1,834 @@
+features
+        Boolean "Feature-0" cardinality [1..5]
+                alternative
+                        Integer "Feature-1" {Price 72}
+                                alternative
+                                        Boolean "Feature-2" {Price 240}
+                                                or
+                                                        Boolean "Feature-3" {Price 886}
+                                                                alternative
+                                                                        String "Feature-5"
+                                                                                alternative
+                                                                                        Boolean "Feature-8" {Price 179}
+                                                                                        Real "Feature-9" {Price 130}
+                                                                                        Integer "Feature-21"
+                                                                                        Boolean "Feature-22"
+                                                                                        Boolean "Feature-44"
+                                                                                        Boolean "Feature-50" {Price 928}
+                                                                                        Boolean "Feature-67"
+                                                                                        Boolean "Feature-122"
+                                                                                        Boolean "Feature-327"
+                                                                                        Boolean "Feature-426" {Price 913}
+                                                                        Integer "Feature-7" {Fun 94}
+                                                                                optional
+                                                                                        Boolean "Feature-15" cardinality [1..5] {Price 272}
+                                                                                        Boolean "Feature-26" {Price 669}
+                                                                                        Boolean "Feature-54" cardinality [1..5]
+                                                                                        Integer "Feature-60" {Price 310, Fun -66}
+                                                                                        Integer "Feature-69"
+                                                                                        Boolean "Feature-292" {Price 420}
+                                                                        Integer "Feature-11"
+                                                                                alternative
+                                                                                        Boolean "Feature-37"
+                                                                                        Integer "Feature-75"
+                                                                                        Boolean "Feature-80"
+                                                                                        Integer "Feature-81" {Price 690}
+                                                                                        String "Feature-216"
+                                                                                        Integer "Feature-234"
+                                                                                        Boolean "Feature-255"
+                                                                                        Boolean "Feature-453" {Fun -50}
+                                                                        Boolean "Feature-25"
+                                                                                mandatory
+                                                                                        Boolean "Feature-63"
+                                                                                        Boolean "Feature-87"
+                                                                                        Boolean "Feature-538" {Price 307}
+                                                                        Real "Feature-52" {Price 424}
+                                                                                or
+                                                                                        Boolean "Feature-137"
+                                                                                        Boolean "Feature-140" {Price 723}
+                                                                                        Boolean "Feature-197" {Price 769, Fun -65}
+                                                                        Integer "Feature-62"
+                                                                                alternative
+                                                                                        Boolean "Feature-121" {Price 934, Fun -26}
+                                                                                        Integer "Feature-193"
+                                                                                        String "Feature-210" {Price 450}
+                                                                                        String "Feature-365" {Price 209}
+                                                                        Integer "Feature-352"
+                                                        Boolean "Feature-74" {Price 243}
+                                                                alternative
+                                                                        Boolean "Feature-161" {Price 290}
+                                                                                [2..2]
+                                                                                        Boolean "Feature-225"
+                                                                                        Real "Feature-241"
+                                                                        String "Feature-250" {Price 804, Fun 39}
+                                                        Boolean "Feature-387" {Price 706}
+                                                                optional
+                                                                        Boolean "Feature-540"
+                                        Boolean "Feature-4" {Price 53}
+                                                mandatory
+                                                        Boolean "Feature-18" {Price 21}
+                                                                [1..1]
+                                                                        Boolean "Feature-39" {Price 994}
+                                                                                alternative
+                                                                                        Boolean "Feature-53" {Price 51}
+                                                                                        Boolean "Feature-58"
+                                                                                        Boolean "Feature-71"
+                                                                                        Boolean "Feature-94"
+                                                                        Boolean "Feature-157" {Price 453}
+                                                                                alternative
+                                                                                        Boolean "Feature-174" {Fun 49}
+                                                                                        String "Feature-266"
+                                                                                        Boolean "Feature-412"
+                                                                                        Boolean "Feature-462"
+                                                                        Integer "Feature-226"
+                                                                                alternative
+                                                                                        Boolean "Feature-525" {Fun -4}
+                                                                        Boolean "Feature-371" cardinality [1..5]
+                                                                                mandatory
+                                                                                        Boolean "Feature-416" {Price 33}
+                                                                        Boolean "Feature-390" {Price 787}
+                                                        Boolean "Feature-19" {Price 976}
+                                                                mandatory
+                                                                        Integer "Feature-40" {Price 843}
+                                                                                mandatory
+                                                                                        String "Feature-152" {Price 802}
+                                                                                        Boolean "Feature-441"
+                                                                        Boolean "Feature-45"
+                                                                                mandatory
+                                                                                        Boolean "Feature-128"
+                                                                                        Integer "Feature-151" cardinality [1..5]
+                                                                                        Integer "Feature-172" {Price 357}
+                                                                                        Boolean "Feature-257"
+                                                                                        Integer "Feature-409" {Price 182}
+                                                                        Boolean "Feature-123" {Price 402}
+                                                                                optional
+                                                                                        Boolean "Feature-263"
+                                                                        Boolean "Feature-232" {Price 586}
+                                                                        Boolean "Feature-469"
+                                                                        Boolean "Feature-507"
+                                                        String "Feature-61" {Price 56}
+                                                                alternative
+                                                                        Boolean "Feature-65" {Price 184}
+                                                                                [4..5]
+                                                                                        Boolean "Feature-76" cardinality [1..5]
+                                                                                        Integer "Feature-79"
+                                                                                        Boolean "Feature-143" {Price 504}
+                                                                                        Integer "Feature-233"
+                                                                                        Boolean "Feature-245" cardinality [1..5] {Price 576}
+                                                                                        Boolean "Feature-323"
+                                                                                        Boolean "Feature-505" {Price 891, Fun -49}
+                                                                        Boolean "Feature-72" cardinality [1..5] {Price 916}
+                                                                                alternative
+                                                                                        Boolean "Feature-77" {Price 27}
+                                                                                        Boolean "Feature-85"
+                                                                                        String "Feature-136"
+                                                                                        String "Feature-146"
+                                                                        Boolean "Feature-73"
+                                                                                alternative
+                                                                                        Boolean "Feature-166" {Fun -35}
+                                                                                        Integer "Feature-242" cardinality [1..5]
+                                                                                        Integer "Feature-459" {Price 558}
+                                                                        String "Feature-105" {Price 450}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-109"
+                                                                                        Boolean "Feature-260" {Price 11}
+                                                                                        Boolean "Feature-448"
+                                                                                        Boolean "Feature-463" {Price 196, Fun 83}
+                                                                        Real "Feature-169" {Price 491}
+                                                                        Boolean "Feature-252" cardinality [1..5]
+                                                                        Boolean "Feature-424" cardinality [1..5] {Price 668}
+                                                                        Boolean "Feature-444" {Price 714}
+                                                        Integer "Feature-86" {Fun -16}
+                                                                alternative
+                                                                        Boolean "Feature-101"
+                                                                                [1..3]
+                                                                                        Integer "Feature-102" {Fun -85}
+                                                                                        Boolean "Feature-138" {Price 158}
+                                                                                        Boolean "Feature-270" cardinality [1..5] {Price 788}
+                                                                                        Boolean "Feature-381"
+                                                                        Boolean "Feature-111" {Price 451, Fun 4}
+                                                                                [1..1]
+                                                                                        Integer "Feature-214" {Price 385}
+                                                        Boolean "Feature-243" {Price 584}
+                                                                or
+                                                                        Boolean "Feature-284" {Price 690}
+                                                                        Boolean "Feature-503" {Price 712}
+                                                                                or
+                                                                                        Boolean "Feature-537" cardinality [1..5] {Price 294}
+                                                        Integer "Feature-291"
+                                                                optional
+                                                                        Boolean "Feature-364"
+                                                                        Boolean "Feature-393" {Price 283}
+                                                        String "Feature-334" cardinality [1..5]
+                                                                [0..2]
+                                                                        Boolean "Feature-359"
+                                                                        Boolean "Feature-431" {Price 543}
+                                                                                [0..2]
+                                                                                        Boolean "Feature-452" cardinality [1..5] {Price 251}
+                                                                                        Real "Feature-478" {Price 517, Fun -46}
+                                        Boolean "Feature-6" {Price 980}
+                                                [4..4]
+                                                        Boolean "Feature-10" cardinality [1..5]
+                                                                optional
+                                                                        Integer "Feature-12" cardinality [1..5]
+                                                                                [4..6]
+                                                                                        Integer "Feature-14" {Price 178}
+                                                                                        Boolean "Feature-17" cardinality [1..5]
+                                                                                        Boolean "Feature-34" {Price 950}
+                                                                                        Integer "Feature-47" {Price 225}
+                                                                                        Boolean "Feature-131"
+                                                                                        Boolean "Feature-408"
+                                                                                        Integer "Feature-523" cardinality [1..5] {Price 244}
+                                                                        Boolean "Feature-16" {Price 205}
+                                                                                alternative
+                                                                                        Integer "Feature-24" {Price 288}
+                                                                                        Boolean "Feature-33" {Price 536}
+                                                                                        Real "Feature-36" {Fun 89}
+                                                                                        Boolean "Feature-57"
+                                                                                        Boolean "Feature-237" {Price 120}
+                                                                                        Boolean "Feature-460" cardinality [1..5]
+                                                                                        Boolean "Feature-467"
+                                                                        Boolean "Feature-115"
+                                                                                alternative
+                                                                                        Boolean "Feature-202"
+                                                                                        Boolean "Feature-490"
+                                                                        Boolean "Feature-213" {Price 15}
+                                                                                alternative
+                                                                                        Boolean "Feature-479"
+                                                                        Boolean "Feature-254"
+                                                                                or
+                                                                                        Boolean "Feature-321"
+                                                                                        Boolean "Feature-386" {Price 233, Fun -91}
+                                                                        Real "Feature-472" {Fun 22}
+                                                        Integer "Feature-97"
+                                                                optional
+                                                                        Boolean "Feature-180"
+                                                                                [0..2]
+                                                                                        Boolean "Feature-189"
+                                                                                        Integer "Feature-337"
+                                                                        Boolean "Feature-280"
+                                                                                mandatory
+                                                                                        Boolean "Feature-310" cardinality [1..5]
+                                                                                        Integer "Feature-325" cardinality [1..5] {Fun 45}
+                                                                                        Integer "Feature-351" {Price 984}
+                                                                                        Boolean "Feature-447" cardinality [1..5] {Fun -99}
+                                                        Boolean "Feature-171"
+                                                                mandatory
+                                                                        Boolean "Feature-177" {Price 958}
+                                                                                [1..1]
+                                                                                        Integer "Feature-516" {Price 387}
+                                                                                        Boolean "Feature-518" {Fun -68}
+                                                                        Boolean "Feature-244"
+                                                        Boolean "Feature-215"
+                                                                mandatory
+                                                                        Integer "Feature-240" cardinality [1..5] {Price 782}
+                                                        Boolean "Feature-357" {Price 60}
+                                        Boolean "Feature-42"
+                                                alternative
+                                                        Boolean "Feature-83" {Price 737, Fun 55}
+                                                                mandatory
+                                                                        Boolean "Feature-100" {Price 256}
+                                                                                alternative
+                                                                                        Boolean "Feature-127"
+                                                                                        Boolean "Feature-133"
+                                                                        Boolean "Feature-104" {Price 752, Fun 35}
+                                                                                [1..2]
+                                                                                        Boolean "Feature-158" cardinality [1..5]
+                                                                                        Boolean "Feature-229"
+                                                                        Boolean "Feature-192" {Price 598}
+                                                                                alternative
+                                                                                        Integer "Feature-332"
+                                                                                        Boolean "Feature-470"
+                                                                        Boolean "Feature-239"
+                                                                                alternative
+                                                                                        Real "Feature-455" {Fun -26}
+                                                        Boolean "Feature-99"
+                                                                mandatory
+                                                                        Boolean "Feature-194" cardinality [1..5]
+                                                                        Boolean "Feature-492" {Price 854}
+                                                        Boolean "Feature-183" {Price 727}
+                                                                mandatory
+                                                                        Boolean "Feature-360"
+                                                                                or
+                                                                                        Boolean "Feature-437" {Price 302, Fun -88}
+                                                                                        Boolean "Feature-502"
+                                                                        Boolean "Feature-414"
+                                                        Integer "Feature-385" {Price 971}
+                                                        Boolean "Feature-403"
+                                        Boolean "Feature-78"
+                                                mandatory
+                                                        Integer "Feature-219" cardinality [1..5] {Price 83, Fun 26}
+                                                                mandatory
+                                                                        Real "Feature-451" {Price 359}
+                                                        Integer "Feature-235"
+                                        Real "Feature-88" cardinality [1..5]
+                                                mandatory
+                                                        Boolean "Feature-107"
+                                                                or
+                                                                        Integer "Feature-347"
+                                                                                [2..2]
+                                                                                        Boolean "Feature-379" cardinality [1..5]
+                                                                                        Boolean "Feature-435"
+                                                                        Boolean "Feature-486" cardinality [1..5] {Price 247}
+                                                                                or
+                                                                                        Boolean "Feature-534" {Price 202}
+                                        Boolean "Feature-118"
+                                                [2..3]
+                                                        Boolean "Feature-203"
+                                                                [0..1]
+                                                                        Boolean "Feature-289" {Price 247}
+                                                                                [0..1]
+                                                                                        Integer "Feature-322"
+                                                                                        String "Feature-529" cardinality [1..5] {Price 511}
+                                                                        Boolean "Feature-423"
+                                                        Boolean "Feature-391"
+                                                        Boolean "Feature-434" {Price 726}
+                                                        Boolean "Feature-527"
+                                        String "Feature-195"
+                                                alternative
+                                                        Boolean "Feature-207" cardinality [1..5] {Price 496, Fun 49}
+                                                                or
+                                                                        Boolean "Feature-230"
+                                                                                [1..1]
+                                                                                        Boolean "Feature-499"
+                                                                        Boolean "Feature-370" cardinality [1..5]
+                                                                                mandatory
+                                                                                        Boolean "Feature-517"
+                                                                        Integer "Feature-410" cardinality [1..5]
+                                                                                [1..1]
+                                                                                        Boolean "Feature-415"
+                                                                        Real "Feature-445"
+                                                        Boolean "Feature-294" {Price 103}
+                                                        Integer "Feature-348" cardinality [1..5] {Price 826, Fun 85}
+                                        Boolean "Feature-461" {Fun -76}
+                                                or
+                                                        Boolean "Feature-496" {Price 359, Fun 6}
+                        Boolean "Feature-13"
+                                alternative
+                                        String "Feature-23" cardinality [1..5] {Price 156}
+                                                [0..6]
+                                                        Boolean "Feature-38" cardinality [1..5]
+                                                                or
+                                                                        Integer "Feature-56" {Price 811}
+                                                                                optional
+                                                                                        Boolean "Feature-68" cardinality [1..5] {Price 444, Fun 91}
+                                                                                        Integer "Feature-238" {Price 37}
+                                                                                        Boolean "Feature-384" {Price 391, Fun -39}
+                                                                        Boolean "Feature-64" {Price 644}
+                                                                                optional
+                                                                                        Boolean "Feature-221"
+                                                                                        Boolean "Feature-281" {Price 511, Fun 35}
+                                                                                        Boolean "Feature-476" cardinality [1..5]
+                                                                        Boolean "Feature-98" {Price 886}
+                                                                                optional
+                                                                                        Boolean "Feature-112" cardinality [1..5] {Price 775}
+                                                                                        String "Feature-119" cardinality [1..5] {Fun -10}
+                                                                                        Integer "Feature-135" cardinality [1..5] {Price 554}
+                                                                                        String "Feature-163" {Price 141}
+                                                                        Boolean "Feature-473" cardinality [1..5] {Price 260}
+                                                                        Boolean "Feature-498" cardinality [1..5]
+                                                                                mandatory
+                                                                                        Boolean "Feature-533"
+                                                        Boolean "Feature-49" {Price 998}
+                                                                alternative
+                                                                        Real "Feature-170" {Price 207}
+                                                        Boolean "Feature-132"
+                                                                alternative
+                                                                        Boolean "Feature-149" {Price 841}
+                                                        Real "Feature-282" {Fun 11}
+                                                                [3..3]
+                                                                        Boolean "Feature-468" cardinality [1..5] {Price 783}
+                                                                        Boolean "Feature-526"
+                                                                        Boolean "Feature-532" {Price 971}
+                                                        Boolean "Feature-346" {Fun 53}
+                                                        Boolean "Feature-358"
+                                                                or
+                                                                        Integer "Feature-362"
+                                                                                [0..1]
+                                                                                        String "Feature-506" {Price 760}
+                                                        Boolean "Feature-429"
+                                                                or
+                                                                        Boolean "Feature-514" {Price 383}
+                                        Boolean "Feature-27"
+                                                alternative
+                                                        Boolean "Feature-82" {Price 65}
+                                                                alternative
+                                                                        Boolean "Feature-159" {Price 318}
+                                                        Boolean "Feature-488" cardinality [1..5] {Price 120}
+                                                                or
+                                                                        Boolean "Feature-512" {Price 388}
+                                        Boolean "Feature-46" {Price 938}
+                                                or
+                                                        Boolean "Feature-162"
+                                                                or
+                                                                        Integer "Feature-515" cardinality [1..5] {Price 13}
+                                                        Boolean "Feature-285"
+                                                                mandatory
+                                                                        Boolean "Feature-508"
+                                        Integer "Feature-48" {Price 426}
+                                                mandatory
+                                                        Boolean "Feature-145" {Price 483}
+                                                                or
+                                                                        Boolean "Feature-264"
+                                                                                or
+                                                                                        Boolean "Feature-331"
+                                                        Boolean "Feature-168" cardinality [1..5] {Price 157, Fun -47}
+                                                                [0..1]
+                                                                        Integer "Feature-466"
+                                                        Boolean "Feature-175" {Price 961}
+                                                                or
+                                                                        Integer "Feature-267" cardinality [1..5] {Price 703}
+                                                                                optional
+                                                                                        String "Feature-275" {Price 684}
+                                                                                        Boolean "Feature-306"
+                                                                                        Boolean "Feature-399"
+                                                        Boolean "Feature-187" {Price 800, Fun -27}
+                                                                or
+                                                                        Boolean "Feature-190"
+                                                                                mandatory
+                                                                                        Boolean "Feature-315" {Price 144}
+                                                                                        Boolean "Feature-421"
+                                                                                        Boolean "Feature-456" {Price 350}
+                                                                                        Boolean "Feature-474"
+                                                                        Boolean "Feature-222"
+                                                                                optional
+                                                                                        String "Feature-427"
+                                                                        Boolean "Feature-288" {Price 67}
+                                                                                [1..1]
+                                                                                        Boolean "Feature-308" {Fun -29}
+                                                                                        Boolean "Feature-398" {Price 534}
+                                                                        Boolean "Feature-303" cardinality [1..5] {Price 690, Fun -83}
+                                                                        Boolean "Feature-440"
+                                                        Integer "Feature-251"
+                                                        Boolean "Feature-489" {Fun -65}
+                                                        Boolean "Feature-541" {Price 331}
+                                        Integer "Feature-513" {Price 807}
+                                        Boolean "Feature-524" {Price 262}
+                        Boolean "Feature-20" {Price 474}
+                                [2..2]
+                                        Boolean "Feature-31" {Price 115}
+                                                alternative
+                                                        Boolean "Feature-116"
+                                                                optional
+                                                                        Boolean "Feature-125" cardinality [1..5]
+                                                                                alternative
+                                                                                        Boolean "Feature-165"
+                                                                                        Boolean "Feature-188"
+                                                                                        Boolean "Feature-290" {Price 492}
+                                                                                        Boolean "Feature-361"
+                                                                                        String "Feature-377" {Price 993}
+                                                                                        Real "Feature-450"
+                                                                        Boolean "Feature-249" {Price 591}
+                                                                                alternative
+                                                                                        Real "Feature-262"
+                                                                                        Boolean "Feature-307" {Price 371, Fun -99}
+                                                                                        Boolean "Feature-407" {Price 914}
+                                                                                        Boolean "Feature-519"
+                                                        Boolean "Feature-147" {Price 157}
+                                                                alternative
+                                                                        Boolean "Feature-405"
+                                                                                alternative
+                                                                                        Boolean "Feature-417"
+                                                                                        Boolean "Feature-539" {Price 272}
+                                        Boolean "Feature-117"
+                                                [0..3]
+                                                        Boolean "Feature-366" {Price 441}
+                                                        Integer "Feature-367"
+                                                                alternative
+                                                                        Boolean "Feature-509" cardinality [1..5] {Price 366}
+                                                        Boolean "Feature-401" {Price 290, Fun 89}
+                                                                optional
+                                                                        Boolean "Feature-428" cardinality [1..5] {Price 143}
+                                                                                alternative
+                                                                                        Integer "Feature-548" cardinality [1..5] {Price 805}
+                                        Boolean "Feature-130" {Price 467, Fun 5}
+                                                or
+                                                        Boolean "Feature-182" {Price 37, Fun -60}
+                                                                optional
+                                                                        Integer "Feature-344" cardinality [1..5] {Price 712, Fun -22}
+                                                                                or
+                                                                                        Boolean "Feature-549" cardinality [1..5] {Fun 89}
+                                                                        Real "Feature-443" cardinality [1..5]
+                                                                                or
+                                                                                        Boolean "Feature-446" {Price 832}
+                                                                        Integer "Feature-501" {Price 648}
+                                                        Boolean "Feature-184" {Price 882}
+                                                                [0..2]
+                                                                        Integer "Feature-200" cardinality [1..5]
+                                                                                mandatory
+                                                                                        Real "Feature-218"
+                                                                                        Boolean "Feature-343" {Price 697}
+                                                                        Boolean "Feature-224"
+                                                                        Boolean "Feature-356"
+                                                        Boolean "Feature-259"
+                                                                [1..1]
+                                                                        Boolean "Feature-311" {Price 976}
+                                                                                optional
+                                                                                        Boolean "Feature-442" cardinality [1..5] {Price 326}
+                                                                        Boolean "Feature-319" {Price 284}
+                                                                                or
+                                                                                        Boolean "Feature-329"
+                                                                        Boolean "Feature-402"
+                                                                                optional
+                                                                                        Boolean "Feature-420" {Fun 2}
+                                                        Boolean "Feature-354"
+                                                                mandatory
+                                                                        Real "Feature-395"
+                                        Integer "Feature-504"
+                        Boolean "Feature-28" {Price 77}
+                                [0..3]
+                                        Boolean "Feature-29" cardinality [1..5] {Price 856}
+                                                mandatory
+                                                        Integer "Feature-32" {Price 237, Fun -94}
+                                                                [1..2]
+                                                                        Boolean "Feature-70" {Price 484}
+                                                                                or
+                                                                                        Boolean "Feature-89"
+                                                                                        Integer "Feature-217"
+                                                                                        Boolean "Feature-246"
+                                                                        Integer "Feature-211" {Price 755}
+                                                        String "Feature-176" cardinality [1..5]
+                                                                optional
+                                                                        Boolean "Feature-191"
+                                                                                or
+                                                                                        Boolean "Feature-372" cardinality [1..5] {Price 63}
+                                                                                        Boolean "Feature-392"
+                                                                                        Boolean "Feature-522"
+                                                                                        Boolean "Feature-547"
+                                                        Boolean "Feature-273" cardinality [1..5] {Price 526}
+                                                                mandatory
+                                                                        Boolean "Feature-378"
+                                                                                mandatory
+                                                                                        Boolean "Feature-436" {Price 333}
+                                                                        Boolean "Feature-482" {Price 944}
+                                                        Boolean "Feature-480" cardinality [1..5] {Price 55}
+                                        Integer "Feature-35" {Price 928}
+                                                alternative
+                                                        Boolean "Feature-51"
+                                                                mandatory
+                                                                        Boolean "Feature-55" {Price 658}
+                                                                                [1..1]
+                                                                                        Boolean "Feature-279" {Fun -83}
+                                                                                        Integer "Feature-286" cardinality [1..5]
+                                                                        Integer "Feature-103" {Price 980}
+                                                                                or
+                                                                                        Real "Feature-247" {Price 184}
+                                                                                        Boolean "Feature-338"
+                                                                                        Boolean "Feature-484" {Price 982}
+                                                                        Boolean "Feature-283" cardinality [1..5]
+                                                                                [0..1]
+                                                                                        Boolean "Feature-298" {Price 368}
+                                                        Boolean "Feature-59" {Fun -35}
+                                                                alternative
+                                                                        Boolean "Feature-199" cardinality [1..5]
+                                                                                optional
+                                                                                        Boolean "Feature-316" {Price 60}
+                                                                                        Boolean "Feature-345" cardinality [1..5] {Price 705}
+                                                                                        Integer "Feature-349" cardinality [1..5] {Price 362}
+                                                                                        Boolean "Feature-388" cardinality [1..5]
+                                                                        Boolean "Feature-419" {Price 467}
+                                                                                alternative
+                                                                                        Boolean "Feature-465"
+                                                        Boolean "Feature-93"
+                                                                mandatory
+                                                                        Boolean "Feature-148" {Price 14, Fun -54}
+                                                                                optional
+                                                                                        Integer "Feature-179" {Price 110, Fun -69}
+                                                                                        String "Feature-201"
+                                                                                        Boolean "Feature-317" {Price 54}
+                                                                                        Integer "Feature-339"
+                                                                        Boolean "Feature-363" {Fun -46}
+                                                                                or
+                                                                                        Boolean "Feature-394" {Price 67}
+                                                                                        Boolean "Feature-404" {Price 845}
+                                                                                        Boolean "Feature-425" {Price 590}
+                                                        String "Feature-95" {Price 463}
+                                                                alternative
+                                                                        String "Feature-96" cardinality [1..5] {Fun -83}
+                                                                                alternative
+                                                                                        Boolean "Feature-196" {Fun 60}
+                                                                                        Boolean "Feature-278" cardinality [1..5] {Price 796}
+                                                                                        Boolean "Feature-430" {Price 446}
+                                                                                        Integer "Feature-511"
+                                                                        Boolean "Feature-141" {Price 256}
+                                                                                alternative
+                                                                                        Boolean "Feature-272" cardinality [1..5] {Price 938}
+                                                                        Real "Feature-156" {Price 994}
+                                                                                alternative
+                                                                                        Boolean "Feature-212" {Price 832}
+                                                                        Boolean "Feature-293" {Price 288, Fun -22}
+                                                                                [1..1]
+                                                                                        Boolean "Feature-383" {Price 903}
+                                                        Integer "Feature-248" cardinality [1..5] {Fun 77}
+                                                                [2..3]
+                                                                        Boolean "Feature-287"
+                                                                        Boolean "Feature-454"
+                                                                                [1..1]
+                                                                                        Integer "Feature-535" cardinality [1..5] {Price 516}
+                                                                        Boolean "Feature-543" {Price 45}
+                                                        Integer "Feature-396" {Price 904}
+                                        Boolean "Feature-84" {Price 43, Fun 68}
+                                                [1..2]
+                                                        Boolean "Feature-91" {Price 718}
+                                                        Boolean "Feature-114" {Price 695}
+                                                                optional
+                                                                        Integer "Feature-497"
+                                                        Boolean "Feature-167"
+                                                                mandatory
+                                                                        Boolean "Feature-312" {Price 843, Fun -11}
+                                                        Boolean "Feature-173" cardinality [1..5] {Price 620}
+                                                                alternative
+                                                                        Boolean "Feature-333"
+                                                                        Real "Feature-422"
+                                                        Integer "Feature-297"
+                                                                alternative
+                                                                        String "Feature-335" {Price 457}
+                                                        Boolean "Feature-528"
+                                        Integer "Feature-110" {Price 562}
+                                                alternative
+                                                        Boolean "Feature-155" {Price 899}
+                                                                alternative
+                                                                        Boolean "Feature-209" {Fun -60}
+                                                                                [0..2]
+                                                                                        Boolean "Feature-271" {Price 408}
+                                                                                        Boolean "Feature-458" {Price 164}
+                                                        Boolean "Feature-206"
+                                                                mandatory
+                                                                        Real "Feature-236"
+                                                                                alternative
+                                                                                        Boolean "Feature-295" {Price 129}
+                                                        Boolean "Feature-457" {Price 941}
+                                                        Boolean "Feature-475"
+                                        Boolean "Feature-120"
+                                                [1..1]
+                                                        Boolean "Feature-154" {Price 162}
+                                                                optional
+                                                                        Boolean "Feature-318" {Price 878}
+                                                                                [1..1]
+                                                                                        Boolean "Feature-340"
+                                                                                        Boolean "Feature-439"
+                                                                        Boolean "Feature-376" {Price 331}
+                                                                        Boolean "Feature-531" {Price 607}
+                                                                        Boolean "Feature-542" cardinality [1..5]
+                                                        Boolean "Feature-400" {Price 843}
+                                                        String "Feature-545"
+                        Boolean "Feature-30"
+                                or
+                                        Real "Feature-43"
+                                                optional
+                                                        Boolean "Feature-66" {Price 31, Fun -99}
+                                                                or
+                                                                        Boolean "Feature-126" {Price 256}
+                                                                                [0..2]
+                                                                                        Boolean "Feature-164" {Price 488}
+                                                                                        Boolean "Feature-485" {Price 610, Fun 69}
+                                                                                        Integer "Feature-530" {Price 488, Fun -67}
+                                                        String "Feature-336"
+                                                                mandatory
+                                                                        Boolean "Feature-433"
+                                                        Integer "Feature-411" cardinality [1..5]
+                                                        Integer "Feature-432"
+                                        Integer "Feature-90" {Price 995}
+                                                mandatory
+                                                        Boolean "Feature-92"
+                                                                alternative
+                                                                        Boolean "Feature-276"
+                                                                                mandatory
+                                                                                        Boolean "Feature-449"
+                                                                        Boolean "Feature-313"
+                                                                                mandatory
+                                                                                        Boolean "Feature-350" {Price 229, Fun 74}
+                                                                        Boolean "Feature-324" {Price 623}
+                                                                                or
+                                                                                        Integer "Feature-389" {Price 795}
+                                                                                        Boolean "Feature-510" {Price 993}
+                                                        Integer "Feature-328" {Price 24, Fun 23}
+                                        Integer "Feature-142"
+                                                optional
+                                                        Boolean "Feature-186" {Fun 2}
+                                                        Boolean "Feature-314" cardinality [1..5] {Price 296}
+                                                        Boolean "Feature-413" {Price 607}
+                                        Boolean "Feature-160" {Price 561}
+                                                [2..2]
+                                                        Boolean "Feature-228"
+                                                                alternative
+                                                                        Boolean "Feature-269" cardinality [1..5] {Price 856}
+                                                                                alternative
+                                                                                        Boolean "Feature-382" {Price 718}
+                                                                        Integer "Feature-406" cardinality [1..5] {Price 743}
+                                                                        Boolean "Feature-491" {Price 970}
+                                                                                mandatory
+                                                                                        Boolean "Feature-494"
+                                                                                        String "Feature-520"
+                                                        Boolean "Feature-258" {Price 205}
+                                                                or
+                                                                        Integer "Feature-342" {Price 623}
+                                                        Boolean "Feature-277" {Price 902}
+                                                                [1..4]
+                                                                        Boolean "Feature-302" {Price 554}
+                                                                        Boolean "Feature-355" cardinality [1..5]
+                                                                        Boolean "Feature-438"
+                                                                                optional
+                                                                                        Boolean "Feature-546" {Price 43}
+                                                                        Boolean "Feature-471" {Price 299}
+                                        Boolean "Feature-341" {Price 128, Fun 19}
+                        Integer "Feature-41" {Price 229}
+                                mandatory
+                                        Boolean "Feature-106"
+                                                mandatory
+                                                        Boolean "Feature-113" {Price 952}
+                                                                [2..3]
+                                                                        Integer "Feature-320"
+                                                                                [2..2]
+                                                                                        Boolean "Feature-374" {Price 261}
+                                                                                        Boolean "Feature-397"
+                                                                        Boolean "Feature-368" {Price 44}
+                                                                                mandatory
+                                                                                        Integer "Feature-500"
+                                                                        Boolean "Feature-373" {Fun 93}
+                                                        Boolean "Feature-144"
+                                                                or
+                                                                        Real "Feature-204" cardinality [1..5]
+                                                                                alternative
+                                                                                        Boolean "Feature-296" {Fun -23}
+                                                                                        Integer "Feature-369"
+                                                                        Boolean "Feature-208" cardinality [1..5] {Price 583}
+                                                                                mandatory
+                                                                                        Boolean "Feature-220"
+                                                                        Boolean "Feature-301"
+                                                                                alternative
+                                                                                        Boolean "Feature-521"
+                                                        Boolean "Feature-150" cardinality [1..5] {Fun -97}
+                                                                mandatory
+                                                                        Boolean "Feature-181" {Price 358}
+                                                                                or
+                                                                                        Boolean "Feature-205"
+                                                                                        Boolean "Feature-261"
+                                                                                        Integer "Feature-309" cardinality [1..5] {Price 566}
+                                                                        Integer "Feature-198"
+                                                                                or
+                                                                                        Boolean "Feature-268" {Price 817}
+                                                                                        Boolean "Feature-326" {Fun -94}
+                                                                                        String "Feature-418" {Fun -14}
+                                                                        Boolean "Feature-299" {Price 365}
+                                                                                [1..2]
+                                                                                        Integer "Feature-375" {Price 638}
+                                                                                        Boolean "Feature-536"
+                                        Integer "Feature-108"
+                                                [1..1]
+                                                        Boolean "Feature-134" {Price 123}
+                                                                alternative
+                                                                        Boolean "Feature-153"
+                                                                        Integer "Feature-495" cardinality [1..5]
+                                        Integer "Feature-124"
+                                                or
+                                                        Boolean "Feature-129"
+                                                                or
+                                                                        Boolean "Feature-139" cardinality [1..5] {Price 602}
+                                                                        String "Feature-227" cardinality [1..5] {Price 957}
+                                                                        Boolean "Feature-231"
+                                                                                alternative
+                                                                                        Boolean "Feature-353"
+                                                                        Boolean "Feature-304" cardinality [1..5]
+                                                        Boolean "Feature-178" {Price 350, Fun 40}
+                                                                [2..2]
+                                                                        Boolean "Feature-380"
+                                                                                optional
+                                                                                        Boolean "Feature-483" {Price 650}
+                                                                        Boolean "Feature-477"
+                                                                                mandatory
+                                                                                        Boolean "Feature-544"
+                                                                        Integer "Feature-481" {Price 58}
+                                                        Boolean "Feature-185" {Fun -18}
+                                                        Boolean "Feature-223" cardinality [1..5] {Price 658}
+                                                                or
+                                                                        Boolean "Feature-300" cardinality [1..5] {Price 923, Fun 92}
+                                                                        Integer "Feature-464" {Price 754}
+                                                        Boolean "Feature-265"
+                                                        Boolean "Feature-305" {Price 245}
+                                                                alternative
+                                                                        Integer "Feature-487" cardinality [1..5] {Price 404}
+                                                                        Boolean "Feature-493" {Price 263}
+                                        Boolean "Feature-253" {Fun 84}
+                                                or
+                                                        Real "Feature-256" {Price 145}
+                                                                alternative
+                                                                        Boolean "Feature-274" cardinality [1..5]
+                                                        Integer "Feature-330" {Price 685}
+
+constraints
+        "Feature-51" => "Feature-269" <=> "Feature-150" & "Feature-30" & "Feature-65" => "Feature-484"
+        "Feature-307".Price == "Feature-487".Price - "Feature-307".Price
+        "Feature-547" <=> "Feature-259" & "Feature-371" <=> "Feature-141" <=> "Feature-421"
+        "Feature-201" == '700585532'
+        len("Feature-61") == 678
+        "Feature-252" => "Feature-202" & "Feature-319" <=> "Feature-307" | "Feature-101" | "Feature-398" => "Feature-117" <=> "Feature-457" <=> "Feature-229" => "Feature-268"
+        "Feature-293" => "Feature-161" & "Feature-488" & "Feature-253" => "Feature-296" | "Feature-26" => "Feature-457" <=> !"Feature-184"
+        "Feature-433" & "Feature-549" | "Feature-34" => "Feature-141" | "Feature-491"
+        avg(Price) > 2784
+        "Feature-130" => "Feature-89" => "Feature-265" & "Feature-94" <=> "Feature-126" | "Feature-187" & "Feature-319" <=> "Feature-483" | "Feature-63" => "Feature-255" | "Feature-84" <=> "Feature-71" | !"Feature-154"
+        "Feature-272" <=> "Feature-94" | "Feature-434" | "Feature-505"
+        "Feature-29" | "Feature-435" => "Feature-203" => "Feature-265" | "Feature-98" & "Feature-154" & "Feature-505" => "Feature-401" <=> "Feature-420" => "Feature-329" & "Feature-58" <=> "Feature-341" & "Feature-298" => "Feature-225"
+        "Feature-61" == '-824622898'
+        "Feature-227".Price > "Feature-160".Price / "Feature-530".Price * "Feature-3".Price / "Feature-36".Fun * "Feature-300".Price + "Feature-344".Fun + "Feature-250".Price + "Feature-307".Price / "Feature-227".Price
+        len("Feature-119") == 787
+        "Feature-354" | "Feature-398" <=> !"Feature-470"
+        "Feature-223".Price + "Feature-249".Price + "Feature-84".Fun != "Feature-464".Price
+        "Feature-293" => "Feature-447" <=> "Feature-173" | "Feature-215" | "Feature-149" | "Feature-153" => "Feature-42" | "Feature-408" <=> "Feature-292" <=> "Feature-148" => "Feature-186" | !"Feature-307"
+        "Feature-64" | "Feature-15" <=> "Feature-431" & "Feature-381" => "Feature-28" & "Feature-490" <=> "Feature-160"
+        "Feature-399" => "Feature-144" & "Feature-430" | "Feature-196" | "Feature-173" => "Feature-109" & "Feature-202" & "Feature-33" => "Feature-519" => "Feature-383" => "Feature-98"
+        len("Feature-334") == 346
+        "Feature-184" <=> "Feature-468" | "Feature-272" <=> "Feature-270" | "Feature-469" <=> "Feature-405" & "Feature-318" & "Feature-131" => "Feature-436" & "Feature-425" <=> "Feature-138" | "Feature-454" <=> !"Feature-371"
+        "Feature-73" <=> "Feature-162"
+        "Feature-479" => "Feature-428" & !"Feature-379"
+        "Feature-36".Fun > "Feature-103".Price + "Feature-155".Price / "Feature-169".Price
+        "Feature-327" <=> "Feature-294" & "Feature-25" | "Feature-130" & "Feature-483" & "Feature-268" <=> "Feature-502" <=> "Feature-245" | "Feature-387" & "Feature-29" => "Feature-8" & "Feature-435" => "Feature-298" | !"Feature-231"
+        "Feature-185" => "Feature-502" <=> "Feature-258" & "Feature-289" & "Feature-436" <=> "Feature-457" <=> "Feature-196" <=> "Feature-138" <=> "Feature-463" & "Feature-122" & "Feature-51"
+        "Feature-192" | "Feature-357" | "Feature-420" | "Feature-419" | "Feature-109"
+        "Feature-294".Price < "Feature-308".Fun - "Feature-424".Price - "Feature-346".Fun - "Feature-90".Price
+        avg(Fun) > 250
+        "Feature-119".Fun * "Feature-145".Price / "Feature-208".Price * "Feature-457".Price > "Feature-183".Price * "Feature-135".Price * "Feature-160".Price
+        "Feature-158" <=> "Feature-531" & "Feature-221" <=> "Feature-399" | !"Feature-350"
+        "Feature-121".Price * "Feature-534".Price == "Feature-386".Price - "Feature-240".Price / "Feature-212".Price
+        "Feature-505".Price + "Feature-514".Price / "Feature-455".Fun * "Feature-26".Price > "Feature-147".Price + "Feature-484".Price
+        "Feature-391" => "Feature-357" | "Feature-199" => "Feature-382" & "Feature-488" <=> "Feature-528" | "Feature-469" => "Feature-73" | "Feature-303" => "Feature-153" <=> "Feature-53" => "Feature-353" & !"Feature-122"
+        "Feature-26".Price / "Feature-318".Price < "Feature-84".Price
+        "Feature-199" => "Feature-87" | "Feature-143" | "Feature-183" | "Feature-51" & !"Feature-192"
+        "Feature-520" == '-1357906698'
+        "Feature-321" => "Feature-187" => "Feature-479" => "Feature-357" & "Feature-549" & "Feature-393" => "Feature-546" & "Feature-313" <=> !"Feature-300"
+        "Feature-186" & "Feature-138" => !"Feature-212"
+        "Feature-139" => "Feature-25" => "Feature-147" | "Feature-491" & "Feature-112" <=> "Feature-268" <=> "Feature-402" => "Feature-34" <=> "Feature-187" & "Feature-27" & "Feature-160" <=> "Feature-400" => !"Feature-249"
+        "Feature-307" => "Feature-391" <=> "Feature-457" & "Feature-315" => "Feature-13" <=> "Feature-252" & "Feature-438" & !"Feature-268"
+        "Feature-147" => "Feature-424" & "Feature-157" | "Feature-306" | "Feature-117" | "Feature-355" => !"Feature-431"
+        "Feature-208" <=> "Feature-137" => "Feature-437" | "Feature-101" => "Feature-379" <=> "Feature-306" => "Feature-381"
+        "Feature-202" => "Feature-19" & "Feature-164" => "Feature-413" <=> "Feature-91" | "Feature-27" & "Feature-363" | "Feature-296" <=> "Feature-526" | "Feature-264" | "Feature-50" <=> "Feature-484"
+        "Feature-222" <=> "Feature-185" & "Feature-469" <=> "Feature-526" & "Feature-485" & "Feature-243" <=> "Feature-428" => "Feature-33" & "Feature-400" & "Feature-540" <=> "Feature-435" <=> "Feature-221" & "Feature-419"
+        "Feature-161" | "Feature-67" => "Feature-194" & "Feature-514" | "Feature-258" & "Feature-272" <=> "Feature-274" | "Feature-423" => !"Feature-428"
+        "Feature-199" => "Feature-127" | "Feature-331" => "Feature-433" <=> "Feature-149" & "Feature-253" <=> "Feature-189" | "Feature-213" & "Feature-99" & "Feature-252" => !"Feature-314"
+        "Feature-484" | "Feature-16" => "Feature-259" | !"Feature-419"
+        "Feature-89" <=> "Feature-398" & "Feature-15" => "Feature-333" => !"Feature-290"
+        "Feature-173" | "Feature-528" <=> "Feature-374" & "Feature-477" <=> "Feature-42" & "Feature-462" & "Feature-331" => "Feature-333" => "Feature-546" <=> "Feature-131" => "Feature-149" & "Feature-465" <=> "Feature-441"
+        "Feature-5" == '771810665'
+        "Feature-386".Price > "Feature-145".Price - "Feature-538".Price - "Feature-284".Price - "Feature-485".Fun + "Feature-446".Price + "Feature-81".Price / "Feature-249".Price * "Feature-281".Price / "Feature-401".Fun * "Feature-111".Fun / "Feature-207".Fun
+        "Feature-239" => "Feature-537" => "Feature-429" | "Feature-353" | "Feature-265" & "Feature-499" & "Feature-458" => "Feature-116" | "Feature-509" <=> !"Feature-346"
+        len("Feature-163") == 523
+        "Feature-298".Price / "Feature-149".Price > "Feature-130".Fun / "Feature-509".Price * "Feature-81".Price
+        "Feature-441" <=> "Feature-199" | "Feature-447" & "Feature-357" => "Feature-323" | "Feature-424" <=> "Feature-89" & "Feature-72" & !"Feature-4"
+        "Feature-436" | "Feature-361" <=> "Feature-430" & "Feature-283" => "Feature-496" => "Feature-431" | "Feature-417" | "Feature-454" & "Feature-148" & "Feature-470" => "Feature-50" => "Feature-296" | "Feature-412"
+        "Feature-488" <=> "Feature-117" & "Feature-65" | "Feature-252" => "Feature-42" & "Feature-187" & "Feature-382" => "Feature-428" => "Feature-115" <=> !"Feature-484"
+        len("Feature-176") == 984
+        "Feature-420" <=> "Feature-64" <=> "Feature-31" | "Feature-483"
+        "Feature-224" | "Feature-38" => "Feature-164" & "Feature-149" => "Feature-405" & "Feature-287" <=> "Feature-140" & "Feature-514" => "Feature-59" <=> "Feature-264" | !"Feature-27"
+        "Feature-212".Price - "Feature-102".Fun + "Feature-249".Price - "Feature-401".Fun + "Feature-447".Fun * "Feature-373".Fun * "Feature-436".Price - "Feature-315".Price / "Feature-152".Price + "Feature-530".Price / "Feature-135".Price * "Feature-341".Fun != "Feature-311".Price * "Feature-173".Price
+        "Feature-463" | "Feature-317" => "Feature-183" | "Feature-311" => "Feature-430" & "Feature-304" & "Feature-58" | "Feature-413" => "Feature-270" & "Feature-260" <=> "Feature-303" | "Feature-27"
+        "Feature-491" => "Feature-225" => "Feature-184" | "Feature-212" | "Feature-498" => "Feature-307" | "Feature-295" | "Feature-239" => "Feature-533" => "Feature-185" & "Feature-315" | "Feature-51" <=> "Feature-16" & "Feature-437"
+        "Feature-173" | "Feature-70" <=> "Feature-45" => "Feature-190" | "Feature-364" & "Feature-298" => "Feature-111"
+        "Feature-22" <=> "Feature-541" & "Feature-414" => "Feature-468" => "Feature-258" => "Feature-202" & "Feature-499" | "Feature-28" => "Feature-114" => "Feature-223" <=> "Feature-37"
+        "Feature-129" => "Feature-128" | "Feature-447" | "Feature-444" <=> "Feature-175" | "Feature-118" => "Feature-70" => "Feature-100" <=> !"Feature-546"
+        "Feature-307" | "Feature-376" | "Feature-483" & "Feature-494" => "Feature-93" => "Feature-295" => "Feature-148" & "Feature-232" & "Feature-253" & "Feature-100" => "Feature-300" <=> "Feature-421"
+        "Feature-199" <=> "Feature-63" & "Feature-0" | "Feature-130" | "Feature-531" => "Feature-374" <=> "Feature-139" | "Feature-540"
+        "Feature-460" => "Feature-353" <=> "Feature-173" => "Feature-467"
+        "Feature-184" | "Feature-317" => "Feature-366" <=> "Feature-89" | "Feature-434" => "Feature-522" | "Feature-327" & "Feature-118" & "Feature-4" & "Feature-490" <=> "Feature-485" & "Feature-147" & "Feature-126" | "Feature-314"
+        "Feature-45" <=> "Feature-525" <=> "Feature-185" | "Feature-355" | "Feature-428" => "Feature-435"
+        "Feature-85" <=> "Feature-194" & "Feature-202" => "Feature-167"
+        "Feature-85" => "Feature-401" <=> "Feature-37" & "Feature-303" <=> "Feature-460" => "Feature-73" | "Feature-358"

--- a/test_resources/parsing/generated/fm1.uvl
+++ b/test_resources/parsing/generated/fm1.uvl
@@ -1,0 +1,820 @@
+features
+        Boolean "Feature-0"
+                alternative
+                        Boolean "Feature-1" {Price 740, Fun -38}
+                                [1..1]
+                                        Boolean "Feature-18"
+                                                [3..3]
+                                                        Boolean "Feature-26" {Price 979}
+                                                                mandatory
+                                                                        Boolean "Feature-32"
+                                                                                alternative
+                                                                                        Boolean "Feature-101" {Price 308}
+                                                                                        Boolean "Feature-168" {Price 895}
+                                                                                        Boolean "Feature-229"
+                                                                        String "Feature-44"
+                                                                                [1..1]
+                                                                                        Real "Feature-60" cardinality [1..5]
+                                                                                        Boolean "Feature-129" cardinality [1..5] {Price 572}
+                                                                                        Boolean "Feature-176" {Price 756}
+                                                                                        Boolean "Feature-253"
+                                                                        Boolean "Feature-54" {Price 809}
+                                                                                mandatory
+                                                                                        Boolean "Feature-327" {Price 851}
+                                                                                        String "Feature-352"
+                                                                                        Boolean "Feature-411" cardinality [1..5]
+                                                                        Boolean "Feature-64"
+                                                                                alternative
+                                                                                        String "Feature-84"
+                                                                                        Boolean "Feature-196" {Fun 0}
+                                                                                        Integer "Feature-316"
+                                                                                        Integer "Feature-513" {Price 92}
+                                                                        Boolean "Feature-72" {Price 329}
+                                                                                mandatory
+                                                                                        String "Feature-126"
+                                                                                        Boolean "Feature-138" {Price 743, Fun 11}
+                                                                                        Boolean "Feature-193"
+                                                                                        Boolean "Feature-296" cardinality [1..5] {Price 245}
+                                                                        String "Feature-369"
+                                                                                or
+                                                                                        Boolean "Feature-460"
+                                                        Integer "Feature-69"
+                                                                or
+                                                                        Real "Feature-115"
+                                                                                alternative
+                                                                                        Boolean "Feature-163" {Price 236}
+                                                                                        Integer "Feature-212" {Price 990, Fun -25}
+                                                                                        Boolean "Feature-310" cardinality [1..5] {Price 549}
+                                                                                        Integer "Feature-324" {Price 866}
+                                                                                        Boolean "Feature-336" {Price 144}
+                                                                                        Boolean "Feature-379" {Price 921}
+                                                                        Boolean "Feature-262" {Price 708}
+                                                                                alternative
+                                                                                        Boolean "Feature-337" {Price 546}
+                                                                        Boolean "Feature-361" {Price 719}
+                                                                        String "Feature-514" {Price 720}
+                                                        Boolean "Feature-231" cardinality [1..5] {Price 375}
+                                                                alternative
+                                                                        Boolean "Feature-254"
+                                                                                mandatory
+                                                                                        Boolean "Feature-403" cardinality [1..5]
+                                                                                        Boolean "Feature-437" cardinality [1..5]
+                                                                                        Boolean "Feature-438"
+                                                                        Boolean "Feature-292"
+                                                                        Boolean "Feature-326"
+                                                                        Integer "Feature-389" {Price 732}
+                                                                        Integer "Feature-402"
+                                                                        Boolean "Feature-457"
+                                                        Integer "Feature-287" {Fun 58}
+                                                        Integer "Feature-314"
+                                        String "Feature-155" cardinality [1..5] {Price 69}
+                                                mandatory
+                                                        Boolean "Feature-318" {Fun 85}
+                                                                or
+                                                                        Integer "Feature-359" {Price 84}
+                                                                        Boolean "Feature-367"
+                                                                                alternative
+                                                                                        Integer "Feature-506" cardinality [1..5]
+                                                                                        Boolean "Feature-547"
+                                                                        Boolean "Feature-512" {Price 933}
+                                        Integer "Feature-218"
+                                                [2..2]
+                                                        Integer "Feature-245" cardinality [1..5] {Price 371, Fun 85}
+                                                                mandatory
+                                                                        Boolean "Feature-474" cardinality [1..5]
+                                                                                alternative
+                                                                                        Integer "Feature-523"
+                                                                        Boolean "Feature-505"
+                                                                        Boolean "Feature-530"
+                                                        Boolean "Feature-270"
+                                                                or
+                                                                        Boolean "Feature-412"
+                                                        Integer "Feature-288" cardinality [1..5] {Price 196}
+                                                        Boolean "Feature-541"
+                                        Boolean "Feature-429"
+                        Boolean "Feature-2"
+                                or
+                                        Boolean "Feature-4"
+                                                alternative
+                                                        Boolean "Feature-6"
+                                                                [2..4]
+                                                                        Boolean "Feature-10" cardinality [1..5] {Price 620}
+                                                                                [0..3]
+                                                                                        Boolean "Feature-48" cardinality [1..5] {Price 64}
+                                                                                        String "Feature-49" cardinality [1..5] {Price 721}
+                                                                                        Boolean "Feature-113"
+                                                                        Boolean "Feature-11"
+                                                                                alternative
+                                                                                        Integer "Feature-33"
+                                                                                        Boolean "Feature-71" {Price 103}
+                                                                                        Boolean "Feature-180" {Price 610}
+                                                                                        Boolean "Feature-342" {Price 282}
+                                                                                        Integer "Feature-426" cardinality [1..5] {Price 257}
+                                                                        Boolean "Feature-20"
+                                                                                mandatory
+                                                                                        Boolean "Feature-47" {Price 852}
+                                                                                        Boolean "Feature-52"
+                                                                                        Boolean "Feature-99" cardinality [1..5]
+                                                                                        Boolean "Feature-137" {Price 550}
+                                                                                        Boolean "Feature-161" {Price 110}
+                                                                                        Boolean "Feature-178" {Price 347}
+                                                                                        Boolean "Feature-366" {Price 188, Fun -8}
+                                                                                        Real "Feature-507"
+                                                                        Boolean "Feature-27" {Price 987}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-59"
+                                                                                        Boolean "Feature-77" {Price 491}
+                                                                                        Boolean "Feature-93"
+                                                                                        Integer "Feature-156"
+                                                                                        Integer "Feature-434"
+                                                                        Boolean "Feature-70"
+                                                                                alternative
+                                                                                        Integer "Feature-225" {Price 828, Fun 62}
+                                                                        Boolean "Feature-133" {Price 856}
+                                                                                alternative
+                                                                                        Boolean "Feature-224"
+                                                                                        Boolean "Feature-364" {Price 880}
+                                                                                        Boolean "Feature-445" cardinality [1..5] {Price 141}
+                                                                        Boolean "Feature-144" cardinality [1..5]
+                                                                                mandatory
+                                                                                        Boolean "Feature-153" {Price 443}
+                                                                                        Boolean "Feature-432"
+                                                                                        Boolean "Feature-454" cardinality [1..5]
+                                                                        Boolean "Feature-173" {Price 149}
+                                                                                optional
+                                                                                        Boolean "Feature-319" {Price 325}
+                                                        Integer "Feature-19"
+                                                                or
+                                                                        Real "Feature-24"
+                                                                                or
+                                                                                        Boolean "Feature-255" {Price 994}
+                                                                        Boolean "Feature-58"
+                                                                                optional
+                                                                                        Boolean "Feature-92" {Price 927, Fun -1}
+                                                                                        Integer "Feature-263" {Price 331}
+                                                                                        Boolean "Feature-273"
+                                                                                        Boolean "Feature-298" {Price 30}
+                                                                                        Boolean "Feature-362" {Fun 67}
+                                                                                        Real "Feature-394" {Price 682}
+                                                                                        Boolean "Feature-433"
+                                                                        Boolean "Feature-104" {Fun -13}
+                                                                                [0..2]
+                                                                                        Boolean "Feature-107" {Price 22}
+                                                                                        Integer "Feature-241" {Price 559}
+                                                                        Boolean "Feature-192" {Fun -19}
+                                                                                [0..3]
+                                                                                        Boolean "Feature-237"
+                                                                                        Boolean "Feature-527"
+                                                                                        Boolean "Feature-537" {Price 572, Fun -100}
+                                                                        Boolean "Feature-247" cardinality [1..5] {Price 986, Fun 1}
+                                                                                or
+                                                                                        Integer "Feature-401" {Price 210}
+                                                                                        Integer "Feature-413"
+                                                                                        Integer "Feature-488"
+                                                                        Boolean "Feature-271" cardinality [1..5] {Price 673}
+                                                                        Integer "Feature-400"
+                                                        String "Feature-159" cardinality [1..5] {Price 41, Fun 80}
+                                                                mandatory
+                                                                        Boolean "Feature-350"
+                                                                                [0..1]
+                                                                                        Boolean "Feature-450"
+                                                                        Integer "Feature-549" {Price 421}
+                                                        Boolean "Feature-214" {Price 725}
+                                                                mandatory
+                                                                        Boolean "Feature-504"
+                                                        Integer "Feature-508" {Price 17}
+                                        Boolean "Feature-5"
+                                                alternative
+                                                        Boolean "Feature-8" {Price 659}
+                                                                mandatory
+                                                                        Integer "Feature-16" {Price 165}
+                                                                                optional
+                                                                                        Real "Feature-40" {Price 461}
+                                                                                        Boolean "Feature-45" {Price 902}
+                                                                                        Boolean "Feature-51" {Fun -90}
+                                                                                        String "Feature-81" {Price 45}
+                                                                                        Boolean "Feature-280"
+                                                                                        Boolean "Feature-354" {Price 123}
+                                                                        Boolean "Feature-105" {Price 362}
+                                                                                alternative
+                                                                                        Boolean "Feature-386" {Fun 13}
+                                                                                        Boolean "Feature-492" {Price 286}
+                                                                                        Real "Feature-520" {Price 643}
+                                                                        Boolean "Feature-351" cardinality [1..5]
+                                                                                [0..1]
+                                                                                        Boolean "Feature-515"
+                                                                        Boolean "Feature-528" {Price 776, Fun 52}
+                                                        Boolean "Feature-14" {Price 578, Fun -31}
+                                                                alternative
+                                                                        String "Feature-29" {Price 850}
+                                                                                [2..2]
+                                                                                        Boolean "Feature-53" {Price 167, Fun 67}
+                                                                                        Boolean "Feature-132" cardinality [1..5]
+                                                                                        Boolean "Feature-209" {Price 178}
+                                                                        Boolean "Feature-43" cardinality [1..5] {Price 469}
+                                                                                [2..2]
+                                                                                        Boolean "Feature-82" {Price 67, Fun 59}
+                                                                                        Boolean "Feature-89"
+                                                                                        Integer "Feature-121"
+                                                                                        Boolean "Feature-131"
+                                                                                        Real "Feature-205" {Price 560, Fun -28}
+                                                                        String "Feature-87"
+                                                                                alternative
+                                                                                        Boolean "Feature-293" cardinality [1..5] {Price 556}
+                                                                                        Boolean "Feature-397" {Price 472}
+                                                                                        Boolean "Feature-524" {Price 469}
+                                                                        Boolean "Feature-97" {Price 440}
+                                                                        Boolean "Feature-167"
+                                                                                mandatory
+                                                                                        Boolean "Feature-331" {Price 617}
+                                                                                        Integer "Feature-395"
+                                                                                        Boolean "Feature-430"
+                                                                        Boolean "Feature-194" {Fun 49}
+                                                                                mandatory
+                                                                                        Integer "Feature-278"
+                                                                        Real "Feature-494" {Price 110}
+                                        Boolean "Feature-56" {Fun 36}
+                                                mandatory
+                                                        Boolean "Feature-90" {Price 623}
+                                                                [0..2]
+                                                                        Integer "Feature-171" {Fun 80}
+                                                                                or
+                                                                                        Boolean "Feature-172"
+                                                                                        Boolean "Feature-199" {Price 503}
+                                                                        Boolean "Feature-294" {Price 286}
+                                                                                mandatory
+                                                                                        Boolean "Feature-325" cardinality [1..5]
+                                                                        Real "Feature-358" {Price 980, Fun -15}
+                                                                        Boolean "Feature-525"
+                                                        Integer "Feature-147"
+                                                        Boolean "Feature-201" {Price 181}
+                                                                alternative
+                                                                        Boolean "Feature-436" {Price 341}
+                                                                        Integer "Feature-509"
+                                                        Boolean "Feature-275"
+                                                                or
+                                                                        Boolean "Feature-496" {Price 989}
+                                                        Boolean "Feature-373"
+                                                                alternative
+                                                                        Integer "Feature-519"
+                                                        Boolean "Feature-390" {Price 832, Fun 66}
+                                        Integer "Feature-98"
+                                                mandatory
+                                                        Boolean "Feature-117"
+                                                                alternative
+                                                                        Boolean "Feature-135"
+                                                                                alternative
+                                                                                        Boolean "Feature-177"
+                                                                                        Boolean "Feature-191" {Price 137}
+                                                                        Boolean "Feature-211" {Fun 22}
+                                                        Integer "Feature-184"
+                                                        Boolean "Feature-489"
+                                        Boolean "Feature-187" {Price 65}
+                                                or
+                                                        Integer "Feature-453" cardinality [1..5]
+                                                        Boolean "Feature-497" {Fun -36}
+                                                                or
+                                                                        Boolean "Feature-502" {Price 650}
+                                                                        Boolean "Feature-538" cardinality [1..5] {Price 376}
+                                        Boolean "Feature-228" {Price 458}
+                                                [0..1]
+                                                        Integer "Feature-252" cardinality [1..5]
+                                        Boolean "Feature-380" cardinality [1..5]
+                                                alternative
+                                                        Boolean "Feature-455"
+                                                        Boolean "Feature-462" cardinality [1..5]
+                                                        Real "Feature-518"
+                                        Boolean "Feature-452" cardinality [1..5] {Price 360}
+                        Boolean "Feature-3" cardinality [1..5] {Price 756}
+                                alternative
+                                        Boolean "Feature-21"
+                                                [0..5]
+                                                        Real "Feature-78" cardinality [1..5] {Price 320}
+                                                                alternative
+                                                                        Integer "Feature-88"
+                                                                                alternative
+                                                                                        Integer "Feature-233" {Price 548}
+                                                                                        Boolean "Feature-238"
+                                                                                        Boolean "Feature-250" cardinality [1..5] {Price 51, Fun 57}
+                                                                                        Integer "Feature-393"
+                                                                                        Boolean "Feature-486" {Price 568}
+                                                                        Boolean "Feature-471" {Price 648}
+                                                                        Integer "Feature-472"
+                                                                                alternative
+                                                                                        Boolean "Feature-539" {Price 656}
+                                                        Integer "Feature-119"
+                                                                optional
+                                                                        Boolean "Feature-227"
+                                                                                alternative
+                                                                                        Boolean "Feature-365" {Price 987}
+                                                        Boolean "Feature-276"
+                                                                mandatory
+                                                                        Boolean "Feature-305" {Price 706}
+                                                                                or
+                                                                                        Real "Feature-545" {Price 80, Fun -72}
+                                                                        Boolean "Feature-340" cardinality [1..5] {Price 67}
+                                                                                or
+                                                                                        Integer "Feature-383" cardinality [1..5] {Price 536}
+                                                                        Boolean "Feature-363" {Price 457}
+                                                        Real "Feature-396"
+                                                        Boolean "Feature-459"
+                                                                alternative
+                                                                        Boolean "Feature-510" {Price 99, Fun 61}
+                                        Boolean "Feature-22" {Price 152}
+                                                alternative
+                                                        Boolean "Feature-112"
+                                                                or
+                                                                        Boolean "Feature-150"
+                                                                                alternative
+                                                                                        Real "Feature-217" {Price 936}
+                                                                                        Real "Feature-268"
+                                                                        Boolean "Feature-274" cardinality [1..5]
+                                                        Boolean "Feature-219" {Price 32}
+                                                                alternative
+                                                                        Boolean "Feature-240"
+                                                                        Boolean "Feature-534"
+                                                        Boolean "Feature-374" {Price 438}
+                                        Real "Feature-23" {Price 46}
+                                                alternative
+                                                        Boolean "Feature-31" cardinality [1..5] {Price 38}
+                                                                [0..2]
+                                                                        Boolean "Feature-230"
+                                                                                alternative
+                                                                                        Real "Feature-479" {Price 571}
+                                                                                        Boolean "Feature-517" {Fun 64}
+                                                                        String "Feature-283" cardinality [1..5] {Price 482}
+                                                        Boolean "Feature-83"
+                                                                mandatory
+                                                                        Boolean "Feature-143"
+                                                                                [0..1]
+                                                                                        Boolean "Feature-160" {Fun 96}
+                                                                        Integer "Feature-376" {Price 916}
+                                                                        Integer "Feature-387" cardinality [1..5] {Price 813}
+                                                        Integer "Feature-442" {Price 955}
+                                                        Boolean "Feature-532" {Price 586}
+                                        Integer "Feature-37" {Price 436}
+                                                optional
+                                                        Boolean "Feature-122" cardinality [1..5] {Price 512}
+                                                                mandatory
+                                                                        Boolean "Feature-170" cardinality [1..5] {Price 522, Fun -40}
+                                                                                optional
+                                                                                        Integer "Feature-221" {Price 203}
+                                                                                        Real "Feature-266"
+                                                                                        Boolean "Feature-339"
+                                                                                        Boolean "Feature-458" {Price 835}
+                                                                        Boolean "Feature-290" {Price 939}
+                                                                                mandatory
+                                                                                        Boolean "Feature-341" {Price 295}
+                                                                                        Real "Feature-529"
+                                                                                        Boolean "Feature-543" {Price 567}
+                                                                        String "Feature-291" {Price 958, Fun -28}
+                                                                                mandatory
+                                                                                        Boolean "Feature-302" cardinality [1..5] {Price 537}
+                                                                                        Integer "Feature-464" {Price 461}
+                                        Boolean "Feature-79" {Price 499}
+                                                alternative
+                                                        Boolean "Feature-94" cardinality [1..5]
+                                                                alternative
+                                                                        Real "Feature-100" {Price 168, Fun 66}
+                                                                                [0..1]
+                                                                                        String "Feature-398" {Price 281}
+                                                                        Boolean "Feature-136" {Price 916}
+                                                                                or
+                                                                                        Boolean "Feature-166" {Price 416}
+                                                                                        Integer "Feature-289" {Price 947}
+                                                                                        Boolean "Feature-444"
+                                                                                        Boolean "Feature-500" cardinality [1..5] {Price 711}
+                                                                        Boolean "Feature-269" {Price 527}
+                                                        Integer "Feature-236" {Price 423}
+                                                        Boolean "Feature-248" {Price 816}
+                                                                mandatory
+                                                                        Integer "Feature-406"
+                                                                        Boolean "Feature-461"
+                                                        Boolean "Feature-313" cardinality [1..5] {Price 35}
+                                                                [0..1]
+                                                                        String "Feature-343"
+                                                                                mandatory
+                                                                                        Boolean "Feature-410" {Fun -53}
+                                                                                        String "Feature-465"
+                                                        Boolean "Feature-328" {Price 803}
+                                                                alternative
+                                                                        Boolean "Feature-441" cardinality [1..5]
+                                                        Integer "Feature-485"
+                                        Boolean "Feature-174" {Price 995}
+                                                alternative
+                                                        Boolean "Feature-257"
+                                                                mandatory
+                                                                        Boolean "Feature-286"
+                                        Boolean "Feature-466" {Price 468}
+                                        Boolean "Feature-548" {Price 688, Fun -89}
+                        Boolean "Feature-7"
+                                [0..2]
+                                        Boolean "Feature-9" {Price 841}
+                                                [4..5]
+                                                        Integer "Feature-12" {Price 750}
+                                                                mandatory
+                                                                        Integer "Feature-13" cardinality [1..5]
+                                                                                optional
+                                                                                        Boolean "Feature-169" {Price 105}
+                                                                                        Integer "Feature-335" cardinality [1..5]
+                                                                                        Integer "Feature-416" {Price 474}
+                                                                        Boolean "Feature-38" cardinality [1..5] {Price 783}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-162" {Price 131}
+                                                                        Boolean "Feature-55"
+                                                                                [1..1]
+                                                                                        Boolean "Feature-134"
+                                                                        Boolean "Feature-95" {Price 796}
+                                                                                alternative
+                                                                                        Boolean "Feature-140"
+                                                                                        Boolean "Feature-186"
+                                                                                        Integer "Feature-215" {Price 991}
+                                                                        Integer "Feature-301" {Fun -35}
+                                                                        Boolean "Feature-542"
+                                                        Boolean "Feature-25" {Price 947}
+                                                                alternative
+                                                                        Boolean "Feature-39" {Price 347}
+                                                                                alternative
+                                                                                        Boolean "Feature-74"
+                                                                                        Integer "Feature-356" {Price 730, Fun -31}
+                                                                                        Boolean "Feature-469"
+                                                                        Boolean "Feature-96"
+                                                                                or
+                                                                                        Boolean "Feature-285"
+                                                                                        Boolean "Feature-487"
+                                                                                        Integer "Feature-511" {Price 245}
+                                                                        Integer "Feature-139" {Fun 71}
+                                                                                alternative
+                                                                                        Boolean "Feature-330" {Price 209}
+                                                                                        Boolean "Feature-448" {Price 249}
+                                                                        Integer "Feature-360" {Price 499}
+                                                        Real "Feature-28" {Price 713}
+                                                                optional
+                                                                        Boolean "Feature-65" {Price 744}
+                                                                                alternative
+                                                                                        Integer "Feature-91" {Price 662}
+                                                                                        Boolean "Feature-244" {Price 49}
+                                                                                        Boolean "Feature-424"
+                                                                                        Integer "Feature-521" {Price 84}
+                                                                        Boolean "Feature-67"
+                                                                                mandatory
+                                                                                        Boolean "Feature-109" {Price 321}
+                                                                                        Boolean "Feature-114"
+                                                                                        Boolean "Feature-182" {Price 567}
+                                                                        Boolean "Feature-282" {Price 816}
+                                                                                alternative
+                                                                                        Integer "Feature-349"
+                                                                                        Integer "Feature-536"
+                                                                        Boolean "Feature-315" {Price 544}
+                                                                                [1..1]
+                                                                                        Integer "Feature-385"
+                                                                        Integer "Feature-425" cardinality [1..5] {Price 630}
+                                                        Boolean "Feature-34"
+                                                                [2..5]
+                                                                        Boolean "Feature-42" {Price 22}
+                                                                                or
+                                                                                        Integer "Feature-61"
+                                                                                        Integer "Feature-110" {Price 165}
+                                                                                        Boolean "Feature-357" {Price 809, Fun -100}
+                                                                                        Boolean "Feature-388" {Price 940}
+                                                                        Integer "Feature-50"
+                                                                                [1..1]
+                                                                                        Boolean "Feature-312"
+                                                                        Boolean "Feature-73" {Price 145, Fun -39}
+                                                                                [1..2]
+                                                                                        Boolean "Feature-111"
+                                                                                        Boolean "Feature-204"
+                                                                                        Boolean "Feature-338" {Price 766, Fun -89}
+                                                                        Boolean "Feature-309"
+                                                                        Boolean "Feature-417" {Price 78}
+                                                        Boolean "Feature-46"
+                                                                mandatory
+                                                                        Boolean "Feature-62" {Price 780}
+                                                                                mandatory
+                                                                                        Boolean "Feature-146"
+                                                                                        Boolean "Feature-154" {Price 98, Fun -91}
+                                                                                        Integer "Feature-188"
+                                                                        Boolean "Feature-311" {Price 376}
+                                                                                mandatory
+                                                                                        Integer "Feature-392"
+                                                                                        Boolean "Feature-456"
+                                                                        Boolean "Feature-371" {Price 108}
+                                                        Boolean "Feature-63" cardinality [1..5] {Price 214}
+                                                                optional
+                                                                        Integer "Feature-66"
+                                                                                alternative
+                                                                                        Boolean "Feature-76" {Price 281}
+                                                                                        Boolean "Feature-86"
+                                                                                        Boolean "Feature-164" {Price 24}
+                                                                                        Boolean "Feature-181"
+                                                                                        Boolean "Feature-246" {Price 375}
+                                                                                        String "Feature-306" {Price 774}
+                                                                                        Integer "Feature-384"
+                                                                        Boolean "Feature-148" cardinality [1..5]
+                                                                                [1..1]
+                                                                                        Integer "Feature-208" cardinality [1..5] {Price 274, Fun 81}
+                                                        Integer "Feature-123" cardinality [1..5]
+                                                                or
+                                                                        Boolean "Feature-260" {Price 155}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-299" cardinality [1..5] {Price 989}
+                                                                                        Boolean "Feature-375"
+                                                                        Boolean "Feature-284"
+                                                                                or
+                                                                                        Integer "Feature-408" cardinality [1..5] {Price 142}
+                                                                                        Integer "Feature-501" {Price 13}
+                                                                        Boolean "Feature-355"
+                                                        Boolean "Feature-220"
+                                                                alternative
+                                                                        Real "Feature-347" {Price 293}
+                                                                        Real "Feature-348" {Price 286}
+                                                                        Integer "Feature-431"
+                                                                        Boolean "Feature-531" {Price 401}
+                                                        Boolean "Feature-242" {Price 866, Fun -49}
+                                        Boolean "Feature-36" {Price 257}
+                                                or
+                                                        Boolean "Feature-409" {Price 491}
+                                                                or
+                                                                        Boolean "Feature-418"
+                                                                                alternative
+                                                                                        Integer "Feature-477"
+                                        Boolean "Feature-57" cardinality [1..5] {Price 819}
+                                                [0..2]
+                                                        Boolean "Feature-102"
+                                                                optional
+                                                                        Boolean "Feature-124" {Price 861}
+                                                                                alternative
+                                                                                        Integer "Feature-320" {Price 627}
+                                                                                        Integer "Feature-391" cardinality [1..5]
+                                                                        Boolean "Feature-202" {Price 637}
+                                                                                alternative
+                                                                                        Boolean "Feature-234"
+                                                                                        Boolean "Feature-323"
+                                                                                        Boolean "Feature-476" cardinality [1..5] {Price 946}
+                                                                                        Integer "Feature-503" {Price 959}
+                                                                        Boolean "Feature-405" cardinality [1..5]
+                                                                        Boolean "Feature-498"
+                                                        Integer "Feature-189"
+                                                                optional
+                                                                        Boolean "Feature-449" cardinality [1..5]
+                                                                                or
+                                                                                        Boolean "Feature-522" {Price 531}
+                                                        Integer "Feature-272" cardinality [1..5]
+                                        Real "Feature-68"
+                                                alternative
+                                                        Boolean "Feature-157"
+                                                                optional
+                                                                        Boolean "Feature-185"
+                                                                        Integer "Feature-216" {Price 111}
+                                                                                mandatory
+                                                                                        Boolean "Feature-243" cardinality [1..5] {Fun -48}
+                                                                        Boolean "Feature-251"
+                                                                                alternative
+                                                                                        Boolean "Feature-381" {Price 758, Fun 82}
+                                                                        Boolean "Feature-277" cardinality [1..5] {Fun -55}
+                                                                                optional
+                                                                                        Boolean "Feature-467"
+                                                                        Real "Feature-535" {Price 208}
+                                                        Boolean "Feature-158"
+                                                                [0..1]
+                                                                        Real "Feature-179" {Price 908}
+                                                                                alternative
+                                                                                        Boolean "Feature-304"
+                                                                                        Integer "Feature-446" cardinality [1..5]
+                                                                        Boolean "Feature-279"
+                                                                                alternative
+                                                                                        Boolean "Feature-346"
+                                                                        Integer "Feature-345"
+                                                        Boolean "Feature-165" {Price 24}
+                                                                alternative
+                                                                        Boolean "Feature-175" {Price 285}
+                                                                                or
+                                                                                        Boolean "Feature-256" {Price 168}
+                                                                                        Real "Feature-332" cardinality [1..5]
+                                                                        Real "Feature-198" {Fun -85}
+                                                                                [1..1]
+                                                                                        Boolean "Feature-264" cardinality [1..5]
+                                                                                        Boolean "Feature-265"
+                                                                        Boolean "Feature-414"
+                                                                                optional
+                                                                                        Integer "Feature-490" cardinality [1..5] {Fun 45}
+                                                                        Boolean "Feature-443" {Price 959}
+                                                        Boolean "Feature-183" {Price 325}
+                                                        Boolean "Feature-195"
+                                                                or
+                                                                        Boolean "Feature-370" {Price 533}
+                                                                        Boolean "Feature-415"
+                                                                                alternative
+                                                                                        String "Feature-423" {Price 181}
+                                                                                        Real "Feature-544"
+                                                        Boolean "Feature-235"
+                                                                alternative
+                                                                        Integer "Feature-420"
+                                                                                alternative
+                                                                                        Boolean "Feature-428" {Fun 47}
+                                                        Integer "Feature-317" {Price 647}
+                                                        Integer "Feature-322" {Price 745}
+                                                                or
+                                                                        Integer "Feature-499"
+                                                                                optional
+                                                                                        Boolean "Feature-526" cardinality [1..5]
+                                        Boolean "Feature-106"
+                                                alternative
+                                                        Boolean "Feature-203"
+                                                                mandatory
+                                                                        Boolean "Feature-249"
+                                                                        Real "Feature-267" {Price 384}
+                                                                                alternative
+                                                                                        Integer "Feature-353"
+                                                                                        Integer "Feature-382" {Price 601}
+                                                                                        Boolean "Feature-427" cardinality [1..5] {Fun -65}
+                                                                        Boolean "Feature-399" cardinality [1..5] {Price 274}
+                                                        Boolean "Feature-223"
+                                                        Boolean "Feature-300" cardinality [1..5] {Price 824}
+                                        Boolean "Feature-127" cardinality [1..5]
+                                        String "Feature-149"
+                                        Boolean "Feature-378"
+                                                or
+                                                        Boolean "Feature-468" {Fun 64}
+                                                        Boolean "Feature-475" {Price 786}
+                        Integer "Feature-15" {Price 826}
+                                alternative
+                                        Integer "Feature-30"
+                                                [0..1]
+                                                        Boolean "Feature-35" {Fun 83}
+                                                                [2..2]
+                                                                        Boolean "Feature-41" {Price 115}
+                                                                                alternative
+                                                                                        Integer "Feature-118"
+                                                                                        Integer "Feature-142" {Price 147}
+                                                                                        Boolean "Feature-303"
+                                                                                        Boolean "Feature-421" {Price 881}
+                                                                                        Integer "Feature-484" {Price 687}
+                                                                        String "Feature-125" {Price 231}
+                                                                                or
+                                                                                        Integer "Feature-130"
+                                                                                        Boolean "Feature-141" cardinality [1..5] {Price 885}
+                                                                                        Integer "Feature-206" {Price 494}
+                                                                                        Integer "Feature-207"
+                                                                        Boolean "Feature-152" {Fun 37}
+                                                                                mandatory
+                                                                                        Boolean "Feature-197" cardinality [1..5]
+                                                                                        String "Feature-344" cardinality [1..5]
+                                                        Boolean "Feature-75"
+                                                                or
+                                                                        Boolean "Feature-80"
+                                                                                optional
+                                                                                        Boolean "Feature-108" {Price 30}
+                                                                                        Boolean "Feature-190" {Price 416}
+                                                                                        Boolean "Feature-232"
+                                                                        Boolean "Feature-85" {Price 234}
+                                                                                optional
+                                                                                        Boolean "Feature-120"
+                                                                        Boolean "Feature-128" {Price 576, Fun -57}
+                                                                                [2..2]
+                                                                                        Boolean "Feature-145" cardinality [1..5]
+                                                                                        Boolean "Feature-151" {Price 661}
+                                                                        Boolean "Feature-200" {Price 411}
+                                                                                or
+                                                                                        Integer "Feature-213" cardinality [1..5] {Price 420}
+                                                                                        Boolean "Feature-407"
+                                                                        Boolean "Feature-281" {Price 116, Fun 5}
+                                                        Boolean "Feature-226" {Price 62}
+                                                                alternative
+                                                                        Boolean "Feature-372" {Price 634}
+                                                                        Boolean "Feature-481"
+                                                                        String "Feature-533" {Price 279}
+                                                        Integer "Feature-308"
+                                                                optional
+                                                                        Boolean "Feature-329" {Price 116}
+                                                                                or
+                                                                                        Boolean "Feature-334" {Price 180}
+                                                                                        Boolean "Feature-451" {Price 251}
+                                                                        Integer "Feature-435" {Price 962}
+                                                                        Boolean "Feature-447" cardinality [1..5]
+                                                                                optional
+                                                                                        Boolean "Feature-463" cardinality [1..5]
+                                                                                        Boolean "Feature-470" {Price 480}
+                                                        Integer "Feature-495" cardinality [1..5]
+                                        Integer "Feature-258" cardinality [1..5] {Price 27}
+                                                alternative
+                                                        Boolean "Feature-259" {Price 272}
+                                                                mandatory
+                                                                        Integer "Feature-483" {Price 538}
+                                                        Boolean "Feature-540" {Price 831}
+                                        Boolean "Feature-261" {Price 500}
+                                                or
+                                                        Boolean "Feature-295" {Price 145}
+                                                                or
+                                                                        Boolean "Feature-493" {Price 637}
+                                        Boolean "Feature-307" cardinality [1..5]
+                                                alternative
+                                                        String "Feature-333" {Price 769}
+                                                                mandatory
+                                                                        Boolean "Feature-368" {Price 406}
+                                                                                alternative
+                                                                                        Real "Feature-473" cardinality [1..5] {Fun 52}
+                                                                        Boolean "Feature-439" {Price 882}
+                                                                        Boolean "Feature-440" {Price 571}
+                                        Real "Feature-419" {Price 169}
+                                        Boolean "Feature-422" cardinality [1..5]
+                                                or
+                                                        Boolean "Feature-478"
+                        String "Feature-17"
+                                [1..3]
+                                        Boolean "Feature-103" cardinality [1..5] {Fun -85}
+                                                mandatory
+                                                        Integer "Feature-116" {Price 510}
+                                                                alternative
+                                                                        Boolean "Feature-222"
+                                                                                alternative
+                                                                                        Boolean "Feature-321"
+                                                                                        Boolean "Feature-404" cardinality [1..5] {Price 879}
+                                                        Boolean "Feature-210" {Price 517}
+                                                        Integer "Feature-239"
+                                        Boolean "Feature-377"
+                                                alternative
+                                                        Boolean "Feature-480" {Price 247, Fun -88}
+                                                        String "Feature-491"
+                                                        Real "Feature-516" cardinality [1..5]
+                                        Boolean "Feature-482" cardinality [1..5] {Price 625}
+                                                mandatory
+                                                        Boolean "Feature-546"
+                        Boolean "Feature-297" {Price 732}
+
+constraints
+        "Feature-305".Price == "Feature-152".Fun * "Feature-404".Price / "Feature-242".Price - "Feature-497".Fun - "Feature-142".Price / "Feature-54".Price * "Feature-423".Price + "Feature-56".Fun * "Feature-179".Price - "Feature-468".Fun * "Feature-214".Price / "Feature-305".Price
+        avg(Fun) > 471
+        "Feature-540" | "Feature-467" <=> "Feature-85" <=> "Feature-421" <=> "Feature-290" <=> "Feature-315" | "Feature-55" & "Feature-281" | "Feature-259" | "Feature-457" => "Feature-312" => "Feature-43" & "Feature-223" => !"Feature-163"
+        "Feature-480" <=> "Feature-364" | "Feature-432" & "Feature-447" & "Feature-452" | "Feature-51" | "Feature-285" <=> "Feature-101" <=> "Feature-111" <=> "Feature-178" => !"Feature-168"
+        len("Feature-29") == 47
+        len("Feature-352") == 256
+        "Feature-226" => "Feature-4" => "Feature-373" <=> "Feature-63" => "Feature-133" => "Feature-249" => "Feature-270"
+        "Feature-249" | "Feature-455" => "Feature-334" <=> "Feature-120" <=> "Feature-452"
+        avg(Price) > 439
+        "Feature-543" => "Feature-242" | "Feature-292" & "Feature-22" | "Feature-168" => "Feature-279" | "Feature-421" <=> "Feature-7" & "Feature-158"
+        "Feature-113" => "Feature-1" & "Feature-448" | "Feature-144" | "Feature-474" => "Feature-42" => "Feature-31" <=> "Feature-238" => "Feature-25" <=> !"Feature-444"
+        "Feature-412" <=> "Feature-63" <=> "Feature-331" => "Feature-64" & "Feature-433" | "Feature-418" & "Feature-148" & "Feature-31" | "Feature-108" => "Feature-120" <=> "Feature-138" | !"Feature-122"
+        "Feature-67" => "Feature-326" => "Feature-83"
+        "Feature-85" | "Feature-452" | "Feature-122" & "Feature-296" <=> "Feature-517" <=> "Feature-526" => !"Feature-274"
+        "Feature-10" | "Feature-103" => "Feature-325" => "Feature-45" | "Feature-6" <=> "Feature-153" => "Feature-377" <=> "Feature-21" | "Feature-273" => "Feature-164" & "Feature-92" => "Feature-436" <=> "Feature-56" & !"Feature-32"
+        "Feature-235" => "Feature-502" | "Feature-112" => "Feature-443" => "Feature-319" <=> !"Feature-56"
+        len("Feature-49") == 771
+        "Feature-102" | "Feature-399" <=> "Feature-259" <=> "Feature-122" | "Feature-321" => "Feature-467" | "Feature-338" | "Feature-339" => "Feature-367" | "Feature-146" => !"Feature-22"
+        "Feature-56".Fun / "Feature-71".Price * "Feature-205".Price * "Feature-208".Price * "Feature-452".Price / "Feature-310".Price < "Feature-277".Fun * "Feature-248".Price - "Feature-51".Fun + "Feature-201".Price * "Feature-306".Price
+        "Feature-331" => "Feature-70" | "Feature-290" | "Feature-430" => "Feature-67"
+        "Feature-36" | "Feature-255" | "Feature-297" | "Feature-270" & "Feature-42" => "Feature-340" => "Feature-539" <=> "Feature-407" <=> "Feature-109" <=> "Feature-79" <=> "Feature-194" => "Feature-59"
+        "Feature-143" | "Feature-102" => "Feature-292" <=> "Feature-517" & "Feature-174" & "Feature-539"
+        "Feature-312" & "Feature-457" | !"Feature-103"
+        "Feature-122" => "Feature-467" | "Feature-296" & "Feature-197" => "Feature-249" <=> "Feature-186" & "Feature-373" <=> "Feature-379" & "Feature-248" & "Feature-145" => "Feature-210" <=> "Feature-450"
+        "Feature-470" => "Feature-277" | "Feature-548" <=> "Feature-71" & "Feature-108" => "Feature-105" | !"Feature-451"
+        "Feature-256" <=> !"Feature-512"
+        avg(Price) > 2158
+        "Feature-412" => "Feature-166" => "Feature-73" & "Feature-6" <=> "Feature-264" & "Feature-480"
+        "Feature-32" => "Feature-259" => "Feature-432" <=> "Feature-274" & "Feature-276" | "Feature-325" & "Feature-6" | "Feature-346" <=> "Feature-250" <=> "Feature-41" => "Feature-255" | "Feature-191" & "Feature-89" <=> !"Feature-437"
+        "Feature-526" => "Feature-452" | "Feature-293" | "Feature-144" => "Feature-548" <=> "Feature-269" <=> "Feature-443" => "Feature-227" <=> "Feature-228" <=> "Feature-168" <=> "Feature-323" => "Feature-21" => "Feature-203" => "Feature-410"
+        "Feature-108" => "Feature-361" & "Feature-67" & "Feature-183" => !"Feature-79"
+        "Feature-248" <=> "Feature-129" <=> !"Feature-181"
+        "Feature-377" <=> "Feature-134" | "Feature-500"
+        "Feature-259".Price * "Feature-174".Price / "Feature-101".Price + "Feature-256".Price * "Feature-250".Fun - "Feature-537".Price + "Feature-205".Price < "Feature-14".Price
+        "Feature-328" <=> "Feature-200" <=> "Feature-228" => "Feature-59" <=> "Feature-456" & "Feature-459" & "Feature-18"
+        "Feature-475" | "Feature-307" => "Feature-158" <=> "Feature-531" | "Feature-79" | "Feature-476" <=> "Feature-256" & "Feature-285" | "Feature-337" <=> "Feature-279" => "Feature-210" <=> !"Feature-232"
+        "Feature-291" == '-1931116597'
+        "Feature-251" | "Feature-186" | !"Feature-307"
+        "Feature-333" == '1456235393'
+        "Feature-280" => "Feature-187" <=> "Feature-440" | "Feature-341" | "Feature-269" => "Feature-231" <=> "Feature-274" => "Feature-364" & "Feature-62" <=> "Feature-102" => "Feature-191" => "Feature-417"
+        "Feature-38" <=> "Feature-174" <=> "Feature-36" => "Feature-62" <=> "Feature-18" <=> "Feature-285" <=> "Feature-251" & "Feature-460" | "Feature-441" <=> "Feature-452" & "Feature-367" & "Feature-34" => "Feature-111" & "Feature-65"
+        "Feature-187".Price + "Feature-170".Price * "Feature-73".Price - "Feature-139".Fun * "Feature-404".Price == "Feature-104".Fun - "Feature-315".Price * "Feature-492".Price - "Feature-37".Price / "Feature-41".Price / "Feature-49".Price + "Feature-452".Price
+        "Feature-279" <=> "Feature-422" <=> "Feature-55" => "Feature-463" & "Feature-117" & "Feature-67" | "Feature-307" <=> "Feature-129"
+        "Feature-209" => "Feature-355" => "Feature-32" & "Feature-476" | "Feature-232" & !"Feature-459"
+        "Feature-44" == '-1303819005'
+        "Feature-318" | "Feature-355" => "Feature-148" <=> "Feature-175" | "Feature-70" | "Feature-181" => "Feature-502" <=> "Feature-197" | "Feature-530" => "Feature-292" & !"Feature-195"
+        "Feature-312" => "Feature-243" <=> "Feature-8" <=> "Feature-170" => "Feature-321" & "Feature-200" <=> "Feature-185" => "Feature-430" | "Feature-85"
+        avg(Price) > 1716
+        "Feature-244" | "Feature-270" | "Feature-251" & "Feature-14" => "Feature-174" | "Feature-195" => "Feature-94" => "Feature-455" | "Feature-355" & "Feature-146" => "Feature-97" & "Feature-227"
+        "Feature-111" => "Feature-46" & "Feature-265" <=> !"Feature-323"
+        "Feature-465" == '843641675'
+        "Feature-337".Price / "Feature-287".Fun * "Feature-174".Price - "Feature-330".Price * "Feature-532".Price / "Feature-357".Price / "Feature-281".Price * "Feature-73".Price / "Feature-535".Price > "Feature-245".Fun * "Feature-470".Price - "Feature-416".Price / "Feature-327".Price + "Feature-381".Price
+        "Feature-328" => "Feature-248" <=> "Feature-534" & "Feature-265" | "Feature-381" <=> "Feature-447" & "Feature-378" <=> "Feature-234" | "Feature-285" <=> "Feature-337" <=> "Feature-357"
+        "Feature-77" => "Feature-169" <=> "Feature-418" <=> "Feature-129"
+        "Feature-42" | "Feature-334" <=> "Feature-34" <=> "Feature-222" & "Feature-229" <=> "Feature-505" & "Feature-170" <=> "Feature-41" <=> "Feature-62" => "Feature-112" | !"Feature-235"
+        "Feature-524" <=> "Feature-162" <=> "Feature-92" => "Feature-250" | "Feature-111" & "Feature-412" | "Feature-129" => "Feature-182" => "Feature-180" => "Feature-456" <=> "Feature-480" <=> "Feature-498" => "Feature-367" <=> "Feature-388"
+        "Feature-109" => "Feature-77" | "Feature-280" & "Feature-190" & "Feature-444" <=> "Feature-46" | "Feature-103"
+        "Feature-367" | "Feature-79" <=> "Feature-199" | "Feature-303" <=> "Feature-111" <=> "Feature-444" <=> "Feature-361" <=> "Feature-135" | "Feature-373" => "Feature-89" & "Feature-34" => "Feature-323"
+        "Feature-343" == '-2046275448'
+        "Feature-502" <=> "Feature-279" <=> "Feature-109" => "Feature-14" <=> "Feature-253" & "Feature-482" => "Feature-83" <=> "Feature-298" <=> "Feature-229" => "Feature-102" <=> "Feature-475" <=> "Feature-21" => "Feature-444" => "Feature-145"
+        "Feature-259" | "Feature-200" | "Feature-76" => "Feature-480"
+        "Feature-404" | "Feature-546" <=> "Feature-297" => "Feature-162" | "Feature-326" => "Feature-83"
+        "Feature-215".Price > "Feature-79".Price / "Feature-215".Price
+        "Feature-373" <=> "Feature-109" <=> "Feature-94" | "Feature-246" <=> "Feature-111" <=> "Feature-22" | "Feature-73" | "Feature-168" <=> "Feature-181" => "Feature-399" => "Feature-517" => "Feature-498" & "Feature-297" <=> "Feature-405"
+        avg(Fun) > 106
+        "Feature-448".Price + "Feature-51".Fun == "Feature-388".Price / "Feature-458".Price
+        "Feature-163" | "Feature-367" => "Feature-457" & "Feature-502" => !"Feature-134"
+        "Feature-363" => "Feature-178" <=> "Feature-417" & "Feature-350" & "Feature-41"
+        "Feature-352" == '-2136655433'
+        "Feature-546" | "Feature-14"
+        "Feature-74" <=> "Feature-298" & "Feature-323" <=> "Feature-238" <=> "Feature-165" | "Feature-101" | "Feature-277" => "Feature-285" & "Feature-361" => "Feature-133" <=> !"Feature-114"
+        "Feature-409" => "Feature-174" | "Feature-517" & "Feature-378" => "Feature-134" | "Feature-539" <=> "Feature-310" | "Feature-199" & "Feature-379" <=> "Feature-421" <=> "Feature-470" <=> "Feature-460" & !"Feature-338"
+        "Feature-535".Price / "Feature-90".Price - "Feature-256".Price * "Feature-27".Price / "Feature-116".Price > "Feature-410".Fun + "Feature-241".Price * "Feature-225".Fun - "Feature-436".Price * "Feature-182".Price * "Feature-298".Price
+        "Feature-530" => "Feature-297" | "Feature-421" & "Feature-455" => "Feature-336" & "Feature-253" <=> "Feature-21" <=> !"Feature-404"
+        "Feature-228" <=> "Feature-71" <=> "Feature-517" => "Feature-240" <=> "Feature-405" <=> "Feature-135" & !"Feature-277"

--- a/test_resources/parsing/generated/fm2.uvl
+++ b/test_resources/parsing/generated/fm2.uvl
@@ -1,0 +1,836 @@
+features
+        Boolean "Feature-0"
+                alternative
+                        Boolean "Feature-1" {Price 272}
+                                or
+                                        Boolean "Feature-2" cardinality [1..5]
+                                                alternative
+                                                        Boolean "Feature-3" {Price 697}
+                                                                mandatory
+                                                                        Boolean "Feature-5" {Price 904}
+                                                                                alternative
+                                                                                        Integer "Feature-6" {Price 285, Fun 96}
+                                                                                        Integer "Feature-16" {Price 366}
+                                                                                        Boolean "Feature-33"
+                                                                                        Boolean "Feature-87"
+                                                                                        Boolean "Feature-101" cardinality [1..5]
+                                                                        Boolean "Feature-8"
+                                                                                or
+                                                                                        Boolean "Feature-18"
+                                                                                        Boolean "Feature-21"
+                                                                                        Integer "Feature-62" {Price 828}
+                                                                                        Integer "Feature-115" cardinality [1..5] {Price 811}
+                                                                                        Boolean "Feature-421" {Price 239}
+                                                                                        Boolean "Feature-522" cardinality [1..5]
+                                                                                        Boolean "Feature-546"
+                                                                        Boolean "Feature-90" cardinality [1..5]
+                                                                                alternative
+                                                                                        Boolean "Feature-249" {Price 96}
+                                                                                        Integer "Feature-391"
+                                                                        Boolean "Feature-137" {Price 922}
+                                                                                [1..1]
+                                                                                        Boolean "Feature-206"
+                                                                        String "Feature-170"
+                                                                                or
+                                                                                        Boolean "Feature-405" {Price 897}
+                                                                                        Boolean "Feature-477"
+                                                                        Boolean "Feature-304" {Price 874}
+                                                                        Boolean "Feature-436"
+                                                                        Boolean "Feature-470" {Price 814}
+                                                                        Integer "Feature-547" {Price 146}
+                                                        Boolean "Feature-14" cardinality [1..5]
+                                                                or
+                                                                        Integer "Feature-19" cardinality [1..5] {Fun 86}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-24" {Price 160}
+                                                                                        Boolean "Feature-25"
+                                                                                        Boolean "Feature-52"
+                                                                                        Boolean "Feature-239"
+                                                                                        Integer "Feature-256" {Price 793}
+                                                                                        String "Feature-396" {Price 725}
+                                                                        String "Feature-35"
+                                                                                alternative
+                                                                                        Boolean "Feature-165" {Price 234}
+                                                                                        Integer "Feature-208" {Price 650}
+                                                                                        Boolean "Feature-423" {Price 245}
+                                                                                        Boolean "Feature-525"
+                                                        Integer "Feature-45"
+                                                                mandatory
+                                                                        Boolean "Feature-495" {Price 320}
+                                                        Boolean "Feature-55" cardinality [1..5]
+                                                                mandatory
+                                                                        Boolean "Feature-73"
+                                                                                or
+                                                                                        Boolean "Feature-140"
+                                                                                        String "Feature-213" {Price 335}
+                                                                        Integer "Feature-116" {Fun 99}
+                                                                        Boolean "Feature-138" cardinality [1..5] {Price 682}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-212" {Price 948}
+                                                                        Boolean "Feature-263"
+                                                                        Boolean "Feature-406" {Price 705, Fun -77}
+                                                        Boolean "Feature-107"
+                                                                or
+                                                                        Boolean "Feature-118" {Price 983}
+                                                                                alternative
+                                                                                        Boolean "Feature-199"
+                                                                                        Boolean "Feature-540"
+                                                        Real "Feature-111" {Price 611}
+                                                                [0..1]
+                                                                        Boolean "Feature-141"
+                                                                                or
+                                                                                        Boolean "Feature-244" {Price 568}
+                                                                        Boolean "Feature-153"
+                                                                                alternative
+                                                                                        Boolean "Feature-218"
+                                                                                        Boolean "Feature-469"
+                                                                        Integer "Feature-169" cardinality [1..5] {Price 528}
+                                                                                mandatory
+                                                                                        Boolean "Feature-266" {Price 21, Fun 53}
+                                                                        Boolean "Feature-408" {Price 91}
+                                                                                optional
+                                                                                        Boolean "Feature-453" {Price 668}
+                                                                        Boolean "Feature-464" {Price 672, Fun 46}
+                                                                                or
+                                                                                        Boolean "Feature-535"
+                                                        Integer "Feature-122" {Price 935, Fun 88}
+                                                                mandatory
+                                                                        Boolean "Feature-270" cardinality [1..5] {Price 67}
+                                                                                alternative
+                                                                                        Integer "Feature-292" {Price 510}
+                                                                                        Boolean "Feature-380"
+                                                        Boolean "Feature-424" cardinality [1..5] {Price 431}
+                                                        Boolean "Feature-437" {Price 684}
+                                                                mandatory
+                                                                        String "Feature-492" cardinality [1..5]
+                                                        Integer "Feature-486"
+                                        Boolean "Feature-9" {Fun 15}
+                                                alternative
+                                                        Boolean "Feature-13" {Price 294}
+                                                                [2..2]
+                                                                        Boolean "Feature-38"
+                                                                                [3..3]
+                                                                                        Integer "Feature-65" cardinality [1..5] {Price 66}
+                                                                                        Boolean "Feature-104" {Price 736}
+                                                                                        Boolean "Feature-144" {Price 10}
+                                                                                        Boolean "Feature-147" cardinality [1..5] {Fun 74}
+                                                                        Real "Feature-42" cardinality [1..5]
+                                                                                optional
+                                                                                        Boolean "Feature-72"
+                                                                                        Boolean "Feature-110" {Price 591}
+                                                                                        Boolean "Feature-175" {Price 343}
+                                                                                        Boolean "Feature-185"
+                                                                                        Real "Feature-196" {Price 507}
+                                                                                        Integer "Feature-532"
+                                                                        Boolean "Feature-74" {Fun 8}
+                                                                                alternative
+                                                                                        Boolean "Feature-299"
+                                                                                        Boolean "Feature-374" {Price 344, Fun 75}
+                                                                        Boolean "Feature-412"
+                                                                        Boolean "Feature-537" {Fun -99}
+                                                                                alternative
+                                                                                        String "Feature-539" {Price 519}
+                                                        Boolean "Feature-57"
+                                                        Boolean "Feature-182" {Price 27}
+                                                        Integer "Feature-183"
+                                                                [1..3]
+                                                                        Boolean "Feature-336" {Price 515}
+                                                                                mandatory
+                                                                                        Boolean "Feature-361"
+                                                                        Boolean "Feature-337" {Price 655}
+                                                                                [1..1]
+                                                                                        Boolean "Feature-490" {Price 317}
+                                                                                        Boolean "Feature-499"
+                                                                                        Boolean "Feature-545" {Price 458}
+                                                                        Real "Feature-418" {Price 44}
+                                                                                alternative
+                                                                                        Boolean "Feature-488" {Price 480}
+                                                                        Boolean "Feature-467" {Price 747}
+                                                                        Boolean "Feature-500" {Price 468}
+                                        Boolean "Feature-10"
+                                                alternative
+                                                        Boolean "Feature-12" cardinality [1..5]
+                                                                alternative
+                                                                        Boolean "Feature-29" cardinality [1..5] {Price 707, Fun 83}
+                                                                        Boolean "Feature-39" cardinality [1..5] {Price 31}
+                                                                                [1..2]
+                                                                                        Integer "Feature-58" {Price 40}
+                                                                                        Boolean "Feature-82"
+                                                                                        Boolean "Feature-325" {Price 475}
+                                                                                        Boolean "Feature-473" {Price 302}
+                                                                                        Integer "Feature-533" cardinality [1..5] {Price 322}
+                                                                        Boolean "Feature-83" cardinality [1..5]
+                                                                                alternative
+                                                                                        Boolean "Feature-158" {Price 174}
+                                                                                        Boolean "Feature-203" {Price 837, Fun 59}
+                                                                                        Boolean "Feature-246" {Price 650}
+                                                                                        Boolean "Feature-352"
+                                                        Integer "Feature-17" {Price 869}
+                                                                [0..1]
+                                                                        Integer "Feature-109"
+                                                                                alternative
+                                                                                        Real "Feature-127" {Price 781, Fun -55}
+                                                                                        Boolean "Feature-134"
+                                                                                        Boolean "Feature-174"
+                                                                                        Boolean "Feature-177" cardinality [1..5] {Price 817}
+                                                                                        Integer "Feature-257"
+                                                                                        Integer "Feature-401"
+                                                                                        Boolean "Feature-411"
+                                                                                        Boolean "Feature-449" cardinality [1..5]
+                                                                        Boolean "Feature-112"
+                                                                                or
+                                                                                        Boolean "Feature-187" {Price 775}
+                                                                        Integer "Feature-197"
+                                                                                or
+                                                                                        Boolean "Feature-310"
+                                                                                        Boolean "Feature-465"
+                                                                        Integer "Feature-248"
+                                                                        Real "Feature-290"
+                                                                                mandatory
+                                                                                        Integer "Feature-512" {Price 147}
+                                                                        Boolean "Feature-443"
+                                                                                or
+                                                                                        Integer "Feature-458" {Fun -8}
+                                                                                        Boolean "Feature-504"
+                                                                        Boolean "Feature-478" {Price 879}
+                                                        Integer "Feature-20"
+                                                                optional
+                                                                        Boolean "Feature-34" {Price 11}
+                                                                                alternative
+                                                                                        Boolean "Feature-159" cardinality [1..5] {Price 513}
+                                                                                        Integer "Feature-168"
+                                                                                        Boolean "Feature-205" {Price 729}
+                                                                                        Boolean "Feature-358"
+                                                                        Boolean "Feature-108"
+                                                                                mandatory
+                                                                                        Boolean "Feature-475" {Price 509}
+                                                                        Real "Feature-216"
+                                                                                or
+                                                                                        Boolean "Feature-397" {Price 580}
+                                                                                        Integer "Feature-431" {Price 700}
+                                                                                        Boolean "Feature-531" cardinality [1..5]
+                                                                        Real "Feature-288" {Price 85}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-462" {Price 283}
+                                                                        Boolean "Feature-511" {Price 371}
+                                                        Real "Feature-22"
+                                                                alternative
+                                                                        Boolean "Feature-36"
+                                                                                mandatory
+                                                                                        Boolean "Feature-150"
+                                                                                        Boolean "Feature-349"
+                                                                                        Boolean "Feature-393" {Price 573}
+                                                                        String "Feature-70" {Fun 51}
+                                                                                alternative
+                                                                                        Boolean "Feature-167"
+                                                                                        Boolean "Feature-309" cardinality [1..5]
+                                                                                        Boolean "Feature-363" {Price 60}
+                                                                                        Integer "Feature-365" cardinality [1..5] {Price 982}
+                                                                                        Integer "Feature-507" cardinality [1..5]
+                                                                        Boolean "Feature-91" {Fun -3}
+                                                                                [2..2]
+                                                                                        Boolean "Feature-95" {Fun 0}
+                                                                                        Real "Feature-171"
+                                                                        Boolean "Feature-94" {Price 860}
+                                                                                alternative
+                                                                                        Boolean "Feature-120"
+                                                                                        Boolean "Feature-265" {Price 975}
+                                                                        String "Feature-237"
+                                                                        Boolean "Feature-250" {Price 811}
+                                                                                mandatory
+                                                                                        Boolean "Feature-282"
+                                                                        Boolean "Feature-319" {Price 834}
+                                                                                alternative
+                                                                                        Boolean "Feature-414" {Price 553}
+                                                                        Boolean "Feature-429"
+                                                        Boolean "Feature-28" {Price 843}
+                                                                [2..2]
+                                                                        Boolean "Feature-78" {Price 304}
+                                                                                or
+                                                                                        Boolean "Feature-132"
+                                                                        Integer "Feature-81" {Price 814}
+                                                                                [0..1]
+                                                                                        Real "Feature-121" {Price 42}
+                                                                                        Boolean "Feature-152" cardinality [1..5] {Price 345}
+                                                                        Boolean "Feature-163" {Price 459, Fun -64}
+                                                                                optional
+                                                                                        Boolean "Feature-285" cardinality [1..5]
+                                                                        Integer "Feature-308" {Price 518}
+                                                        Boolean "Feature-61" cardinality [1..5]
+                                                                mandatory
+                                                                        Integer "Feature-103" cardinality [1..5]
+                                                                                alternative
+                                                                                        Boolean "Feature-157" {Price 762}
+                                                                                        Integer "Feature-329"
+                                                                                        Boolean "Feature-354" {Price 144}
+                                                                        Boolean "Feature-119"
+                                                                        Real "Feature-454"
+                                                        Boolean "Feature-231"
+                                                                alternative
+                                                                        Integer "Feature-273" {Price 917}
+                                                                                [0..1]
+                                                                                        Integer "Feature-382"
+                                                                        Boolean "Feature-371" {Price 56, Fun 91}
+                                        Boolean "Feature-15" cardinality [1..5] {Price 937}
+                                                alternative
+                                                        Boolean "Feature-26" cardinality [1..5]
+                                                                [0..3]
+                                                                        Boolean "Feature-67"
+                                                                                or
+                                                                                        Integer "Feature-117" cardinality [1..5]
+                                                                                        Boolean "Feature-339"
+                                                                        Integer "Feature-77" {Price 489}
+                                                                                mandatory
+                                                                                        Boolean "Feature-176" {Price 664}
+                                                                                        Boolean "Feature-254" {Price 363}
+                                                                                        Boolean "Feature-350" {Price 701}
+                                                                        Integer "Feature-164" {Price 681}
+                                                                                optional
+                                                                                        Boolean "Feature-198" cardinality [1..5] {Price 238}
+                                                                        Boolean "Feature-377" {Price 363, Fun 34}
+                                                                                alternative
+                                                                                        Boolean "Feature-479" {Fun -96}
+                                                        Integer "Feature-30" {Fun 19}
+                                                                alternative
+                                                                        Boolean "Feature-48" {Price 798}
+                                                                                or
+                                                                                        Boolean "Feature-105" {Price 249}
+                                                                                        Boolean "Feature-180" cardinality [1..5]
+                                                                                        Boolean "Feature-211" {Fun 43}
+                                                                        Integer "Feature-156" {Price 584}
+                                                                                mandatory
+                                                                                        Boolean "Feature-280" cardinality [1..5] {Price 583}
+                                                                                        Boolean "Feature-311" {Price 550}
+                                                                                        Integer "Feature-317" {Price 332}
+                                                                                        Boolean "Feature-416" {Price 429}
+                                                                        Integer "Feature-259" {Price 548, Fun 32}
+                                                                                mandatory
+                                                                                        Boolean "Feature-356" cardinality [1..5] {Fun 59}
+                                                                                        Boolean "Feature-387" cardinality [1..5] {Price 846, Fun 36}
+                                                                        Integer "Feature-342" {Price 593, Fun 67}
+                                                                                or
+                                                                                        Boolean "Feature-398" {Fun -5}
+                                                                                        Boolean "Feature-515" {Price 295}
+                                                        Boolean "Feature-53" {Price 255}
+                                                                alternative
+                                                                        String "Feature-99" cardinality [1..5]
+                                                                                alternative
+                                                                                        Boolean "Feature-330"
+                                                                                        String "Feature-498" {Price 853}
+                                                                        Integer "Feature-100" {Price 927}
+                                                                                alternative
+                                                                                        Boolean "Feature-229" {Price 536}
+                                                                                        Boolean "Feature-245" cardinality [1..5]
+                                                                                        Integer "Feature-395" {Price 557}
+                                                                        Boolean "Feature-301"
+                                                                                alternative
+                                                                                        Boolean "Feature-313"
+                                                                                        Boolean "Feature-335"
+                                                                        Boolean "Feature-385" {Price 95, Fun 34}
+                                                                                mandatory
+                                                                                        Boolean "Feature-461" {Price 162}
+                                                                        Boolean "Feature-459" cardinality [1..5] {Price 402}
+                                                                        Boolean "Feature-468" {Price 823}
+                                                        Real "Feature-142"
+                                                                optional
+                                                                        Boolean "Feature-276" {Price 569}
+                                                                                mandatory
+                                                                                        Boolean "Feature-318" {Price 874}
+                                                                                        Boolean "Feature-420" cardinality [1..5] {Price 578}
+                                        Boolean "Feature-23" cardinality [1..5]
+                                                mandatory
+                                                        Boolean "Feature-31" {Price 668, Fun -64}
+                                                                alternative
+                                                                        Boolean "Feature-37" {Price 662}
+                                                                                mandatory
+                                                                                        Boolean "Feature-41"
+                                                                                        Boolean "Feature-56" {Price 880}
+                                                                                        Integer "Feature-84" cardinality [1..5] {Price 213}
+                                                                                        Boolean "Feature-124" {Price 847, Fun 7}
+                                                                                        Boolean "Feature-129" {Price 500}
+                                                                                        Boolean "Feature-201" {Price 531}
+                                                                                        Boolean "Feature-234" cardinality [1..5] {Price 321}
+                                                                                        Boolean "Feature-279"
+                                                                                        Boolean "Feature-514" {Price 314}
+                                                                        Boolean "Feature-51" cardinality [1..5]
+                                                                                or
+                                                                                        Real "Feature-243" cardinality [1..5]
+                                                                                        Integer "Feature-287" {Price 467, Fun 50}
+                                                                                        Boolean "Feature-485"
+                                                                        Boolean "Feature-92" {Price 602, Fun 13}
+                                                                                or
+                                                                                        Integer "Feature-135" cardinality [1..5]
+                                                                                        Boolean "Feature-204" cardinality [1..5]
+                                                                        Boolean "Feature-155" {Price 325}
+                                                                                [1..1]
+                                                                                        Boolean "Feature-368" {Price 255}
+                                                                                        Boolean "Feature-501" {Price 616}
+                                                                        Boolean "Feature-160"
+                                                                                alternative
+                                                                                        Integer "Feature-181" cardinality [1..5] {Price 640, Fun 48}
+                                                                                        Integer "Feature-526" {Price 621, Fun -81}
+                                                        Integer "Feature-46" {Price 450}
+                                                                alternative
+                                                                        Boolean "Feature-66" {Price 697, Fun -100}
+                                                                                alternative
+                                                                                        Boolean "Feature-85" {Price 424, Fun 45}
+                                                                                        Integer "Feature-509" {Price 525}
+                                                                        Integer "Feature-76"
+                                                                                or
+                                                                                        Integer "Feature-235" {Price 692}
+                                                                                        Integer "Feature-275"
+                                                                        Boolean "Feature-106"
+                                                                                mandatory
+                                                                                        Boolean "Feature-125"
+                                                                                        Boolean "Feature-192"
+                                                                                        Boolean "Feature-225" {Price 162}
+                                                                                        Integer "Feature-262"
+                                                                                        String "Feature-445" cardinality [1..5] {Price 487}
+                                                                                        Boolean "Feature-542" {Price 851}
+                                                                        String "Feature-161" cardinality [1..5] {Price 509}
+                                                                                mandatory
+                                                                                        Integer "Feature-402" {Price 721}
+                                                                        Boolean "Feature-215"
+                                                                                alternative
+                                                                                        Boolean "Feature-298" {Price 682}
+                                                                        Integer "Feature-432" cardinality [1..5] {Price 891}
+                                                        Boolean "Feature-253"
+                                                        Boolean "Feature-328" {Price 550, Fun -41}
+                                                                [1..2]
+                                                                        Boolean "Feature-347" cardinality [1..5]
+                                                                                mandatory
+                                                                                        Integer "Feature-519" cardinality [1..5] {Price 258}
+                                                                        Boolean "Feature-373"
+                                                                                alternative
+                                                                                        Boolean "Feature-446" cardinality [1..5] {Price 481}
+                                                        Boolean "Feature-343" cardinality [1..5]
+                                        Integer "Feature-43" cardinality [1..5] {Price 600}
+                                                [1..1]
+                                                        Boolean "Feature-334" {Price 863}
+                                                        String "Feature-439"
+                                                                optional
+                                                                        Real "Feature-487" cardinality [1..5] {Price 153}
+                                                                        Boolean "Feature-505" cardinality [1..5]
+                                                                                [1..1]
+                                                                                        Boolean "Feature-530" {Price 848}
+                                        Integer "Feature-60" {Price 736, Fun 27}
+                                                mandatory
+                                                        Boolean "Feature-98"
+                                                                mandatory
+                                                                        Boolean "Feature-362" {Price 547}
+                                                                        Boolean "Feature-389"
+                                                                                or
+                                                                                        Boolean "Feature-448"
+                                                        Boolean "Feature-131" {Price 688}
+                                                        Boolean "Feature-172" cardinality [1..5] {Price 538}
+                                                                mandatory
+                                                                        Integer "Feature-419"
+                                                        Boolean "Feature-188" {Price 714}
+                                                                optional
+                                                                        Integer "Feature-190" {Price 843}
+                                                                                alternative
+                                                                                        Boolean "Feature-326"
+                                                                                        Integer "Feature-372" {Price 986}
+                                                                        Boolean "Feature-230"
+                                                                                alternative
+                                                                                        Boolean "Feature-238" {Price 97}
+                                                                        Boolean "Feature-274" cardinality [1..5] {Price 909}
+                                                                                [1..1]
+                                                                                        Boolean "Feature-341" {Price 351, Fun 2}
+                                                                                        Boolean "Feature-394" {Price 750}
+                                                                        Integer "Feature-293"
+                                                                                alternative
+                                                                                        Integer "Feature-369" {Price 61}
+                                                                        Integer "Feature-320" {Price 775}
+                                                                                alternative
+                                                                                        Integer "Feature-534" cardinality [1..5]
+                                                                        Boolean "Feature-322"
+                                                                                alternative
+                                                                                        Boolean "Feature-344" {Price 740}
+                                                                        Real "Feature-366"
+                                                        Boolean "Feature-307"
+                                        Boolean "Feature-193"
+                                        Boolean "Feature-272"
+                                        Boolean "Feature-496"
+                        Integer "Feature-4" cardinality [1..5]
+                                mandatory
+                                        Boolean "Feature-139" {Fun 69}
+                                                alternative
+                                                        Boolean "Feature-214" {Price 119}
+                                                        Boolean "Feature-286"
+                                                                or
+                                                                        Boolean "Feature-407"
+                                                                                mandatory
+                                                                                        Boolean "Feature-471" cardinality [1..5]
+                                                                                        Boolean "Feature-476" {Fun -98}
+                                                        Real "Feature-390"
+                                                                or
+                                                                        Boolean "Feature-447" {Price 576}
+                                                        Boolean "Feature-481" {Price 647}
+                                        Boolean "Feature-220" {Price 552}
+                                                [0..1]
+                                                        Boolean "Feature-480" {Price 636}
+                                        Integer "Feature-333"
+                                                [1..1]
+                                                        Boolean "Feature-386" {Price 314}
+                                                                mandatory
+                                                                        Boolean "Feature-427" {Price 572, Fun -31}
+                        Boolean "Feature-7" cardinality [1..5] {Price 76}
+                                optional
+                                        Integer "Feature-11"
+                                                or
+                                                        Boolean "Feature-27"
+                                                                [1..4]
+                                                                        Boolean "Feature-40" cardinality [1..5] {Price 903}
+                                                                                [6..7]
+                                                                                        Boolean "Feature-44" cardinality [1..5]
+                                                                                        Boolean "Feature-63" cardinality [1..5] {Price 620}
+                                                                                        Boolean "Feature-68" {Price 927}
+                                                                                        Integer "Feature-128"
+                                                                                        Boolean "Feature-149" {Price 108, Fun 36}
+                                                                                        Boolean "Feature-370"
+                                                                                        Boolean "Feature-435" {Price 947, Fun -95}
+                                                                        Real "Feature-69" {Price 52}
+                                                                                or
+                                                                                        Boolean "Feature-136" {Price 263}
+                                                                        Boolean "Feature-93"
+                                                                        Boolean "Feature-207" {Price 886}
+                                                                        Boolean "Feature-441"
+                                                        Boolean "Feature-88" {Fun -83}
+                                                                alternative
+                                                                        Boolean "Feature-145" {Price 980}
+                                                                                or
+                                                                                        Boolean "Feature-191" cardinality [1..5] {Price 983}
+                                                                                        Integer "Feature-355"
+                                                                                        Integer "Feature-543" {Fun 25}
+                                                                        Boolean "Feature-146" {Price 521}
+                                                                                or
+                                                                                        Boolean "Feature-315" {Price 193}
+                                                                        Boolean "Feature-451" {Price 159}
+                                                        Integer "Feature-102"
+                                                                mandatory
+                                                                        Integer "Feature-166" cardinality [1..5] {Price 187}
+                                                                                alternative
+                                                                                        Boolean "Feature-264" cardinality [1..5] {Price 759}
+                                                                        Boolean "Feature-189" cardinality [1..5]
+                                                                                or
+                                                                                        Boolean "Feature-221"
+                                                                                        Boolean "Feature-223" cardinality [1..5] {Price 601}
+                                                                                        Boolean "Feature-226" cardinality [1..5] {Price 313}
+                                                                        Integer "Feature-233"
+                                                                                mandatory
+                                                                                        Boolean "Feature-433" cardinality [1..5] {Price 168}
+                                                                                        Real "Feature-528" {Price 93}
+                                                                        Boolean "Feature-306"
+                                                                                optional
+                                                                                        Boolean "Feature-422"
+                                                                                        Integer "Feature-455" cardinality [1..5]
+                                                        Real "Feature-232" {Fun 85}
+                                                                or
+                                                                        Boolean "Feature-289"
+                                                                                optional
+                                                                                        Boolean "Feature-302" cardinality [1..5]
+                                                                                        Boolean "Feature-444"
+                                                                        Integer "Feature-463"
+                                                        Boolean "Feature-338" cardinality [1..5] {Price 648}
+                                                                [1..1]
+                                                                        Integer "Feature-428" cardinality [1..5] {Price 65}
+                                        Boolean "Feature-32" {Price 452}
+                                                mandatory
+                                                        Boolean "Feature-54" {Price 766}
+                                                                or
+                                                                        Boolean "Feature-79" {Price 507}
+                                                                                optional
+                                                                                        Real "Feature-86" {Price 58}
+                                                                                        Boolean "Feature-96" {Price 781}
+                                                                                        Integer "Feature-133" {Fun 3}
+                                                                                        Integer "Feature-236" cardinality [1..5] {Price 272}
+                                                                                        Boolean "Feature-294" cardinality [1..5] {Price 140}
+                                                                                        Boolean "Feature-332"
+                                                                        Boolean "Feature-323"
+                                                                                alternative
+                                                                                        Boolean "Feature-404" {Price 19}
+                                                        Integer "Feature-75"
+                                                                alternative
+                                                                        Real "Feature-222" {Price 805}
+                                                                        Boolean "Feature-268" {Price 508}
+                                                                        Boolean "Feature-417" {Price 800, Fun -65}
+                                                                                alternative
+                                                                                        Integer "Feature-517"
+                                                        Boolean "Feature-114" {Price 44}
+                                                                mandatory
+                                                                        Real "Feature-148" cardinality [1..5]
+                                                                                mandatory
+                                                                                        Boolean "Feature-278" {Price 132}
+                                                                        Boolean "Feature-210" cardinality [1..5] {Price 455}
+                                                                                alternative
+                                                                                        Boolean "Feature-538" {Price 205}
+                                                                        Boolean "Feature-297" cardinality [1..5]
+                                                                                optional
+                                                                                        Boolean "Feature-305" {Price 591, Fun 72}
+                                                                                        Boolean "Feature-327" {Price 645}
+                                                                        Boolean "Feature-331" cardinality [1..5]
+                                                                                alternative
+                                                                                        Real "Feature-388" {Price 998}
+                                                                        Integer "Feature-403" {Price 61}
+                                                        Boolean "Feature-271" {Price 644, Fun -53}
+                                                                or
+                                                                        Boolean "Feature-312" {Price 215}
+                                                                                alternative
+                                                                                        Boolean "Feature-381" {Price 857}
+                                                                        String "Feature-348"
+                                                                        Boolean "Feature-359" {Fun -87}
+                                        Boolean "Feature-47" {Fun 16}
+                                                or
+                                                        Boolean "Feature-89" cardinality [1..5] {Price 245}
+                                                                mandatory
+                                                                        Boolean "Feature-291"
+                                                                                or
+                                                                                        Boolean "Feature-360" {Fun 79}
+                                                                                        Boolean "Feature-518"
+                                                        Boolean "Feature-97" {Price 553}
+                                                                alternative
+                                                                        Boolean "Feature-321" {Price 878}
+                                        Integer "Feature-71" {Price 338}
+                                                or
+                                                        Boolean "Feature-80" cardinality [1..5] {Price 819}
+                                                                [1..4]
+                                                                        Boolean "Feature-154"
+                                                                                [2..2]
+                                                                                        Boolean "Feature-353" {Price 144}
+                                                                                        Boolean "Feature-384" {Price 955}
+                                                                        Integer "Feature-184" cardinality [1..5] {Price 560, Fun 36}
+                                                                                alternative
+                                                                                        Boolean "Feature-247" {Price 219}
+                                                                                        Boolean "Feature-474" {Price 214}
+                                                                        Boolean "Feature-241"
+                                                                        Boolean "Feature-521" {Price 311}
+                                                        Boolean "Feature-357" cardinality [1..5]
+                                                                optional
+                                                                        Integer "Feature-536" {Price 234}
+                                        Boolean "Feature-178"
+                                                or
+                                                        Boolean "Feature-284" {Price 139}
+                                                        Boolean "Feature-296" cardinality [1..5]
+                                                                or
+                                                                        Boolean "Feature-383"
+                                                        Real "Feature-438"
+                                                                alternative
+                                                                        Boolean "Feature-489" {Price 764}
+                                                                        Boolean "Feature-503" cardinality [1..5] {Fun -14}
+                                                                        Boolean "Feature-541" {Price 137}
+                        Integer "Feature-49"
+                                [3..3]
+                                        Boolean "Feature-59" {Price 554}
+                                                [1..1]
+                                                        Boolean "Feature-173" cardinality [1..5] {Price 306}
+                                                                mandatory
+                                                                        Boolean "Feature-186" {Price 696}
+                                                                                alternative
+                                                                                        Boolean "Feature-345" cardinality [1..5] {Price 518}
+                                                                        Real "Feature-351" {Price 315}
+                                                                                mandatory
+                                                                                        Boolean "Feature-413"
+                                                                                        Integer "Feature-466" {Price 737, Fun -3}
+                                                                        Boolean "Feature-378" cardinality [1..5] {Price 864}
+                                                        Boolean "Feature-195"
+                                                        Integer "Feature-217"
+                                                                [0..2]
+                                                                        Integer "Feature-227" {Price 591}
+                                                                        Integer "Feature-314"
+                                                                                alternative
+                                                                                        Boolean "Feature-523"
+                                                                        Real "Feature-399" cardinality [1..5]
+                                        Real "Feature-143"
+                                                [0..3]
+                                                        Boolean "Feature-162" {Fun -96}
+                                                                alternative
+                                                                        Boolean "Feature-410" cardinality [1..5]
+                                                                                alternative
+                                                                                        Boolean "Feature-425"
+                                                                        Boolean "Feature-430"
+                                                                        Boolean "Feature-527" {Price 388}
+                                                        Boolean "Feature-179" {Price 378}
+                                                                alternative
+                                                                        Real "Feature-295"
+                                                                        String "Feature-392" cardinality [1..5] {Fun 26}
+                                                                        Boolean "Feature-506"
+                                                        Integer "Feature-375" {Price 990}
+                                                                or
+                                                                        Boolean "Feature-508" cardinality [1..5] {Price 189}
+                                                        Boolean "Feature-442" {Price 549}
+                                                                mandatory
+                                                                        Integer "Feature-452"
+                                                        Integer "Feature-524" {Price 534}
+                                        Integer "Feature-544" {Fun 91}
+                        Boolean "Feature-50"
+                                alternative
+                                        Real "Feature-126" {Price 307}
+                                                or
+                                                        Integer "Feature-219" cardinality [1..5] {Price 640, Fun 71}
+                                                                [0..1]
+                                                                        Boolean "Feature-426"
+                                                                                or
+                                                                                        Real "Feature-472" {Price 371}
+                                                        Boolean "Feature-242" {Price 898}
+                                                                [3..3]
+                                                                        Boolean "Feature-255"
+                                                                                alternative
+                                                                                        Integer "Feature-258"
+                                                                                        Boolean "Feature-303" {Price 562}
+                                                                        Boolean "Feature-300" {Price 764}
+                                                                                mandatory
+                                                                                        Integer "Feature-400" {Price 399}
+                                                                        Boolean "Feature-491" {Price 699}
+                                                        Boolean "Feature-283" {Price 596}
+                                                                alternative
+                                                                        Boolean "Feature-482" {Price 22}
+                                                                                or
+                                                                                        Boolean "Feature-502" {Price 238}
+                                                        Integer "Feature-457" cardinality [1..5]
+                                        Real "Feature-251"
+                                                or
+                                                        Integer "Feature-261" cardinality [1..5] {Fun 93}
+                                                                mandatory
+                                                                        Boolean "Feature-513" {Price 356, Fun -12}
+                        Boolean "Feature-64" cardinality [1..5]
+                                alternative
+                                        Boolean "Feature-113" cardinality [1..5] {Price 543}
+                                                mandatory
+                                                        Boolean "Feature-434" {Price 526}
+                                                        String "Feature-516" {Price 601}
+                                                                [0..1]
+                                                                        Boolean "Feature-548" cardinality [1..5]
+                                                        Boolean "Feature-520" cardinality [1..5] {Fun -53}
+                                        Integer "Feature-202" {Price 589, Fun 75}
+                                                mandatory
+                                                        Real "Feature-228"
+                                                                or
+                                                                        Integer "Feature-415"
+                                                                        Integer "Feature-440" cardinality [1..5] {Price 588}
+                                                                                [2..2]
+                                                                                        Boolean "Feature-484" {Price 183}
+                                                                                        Boolean "Feature-497"
+                                                                                        Boolean "Feature-549"
+                                                        Boolean "Feature-316" {Price 787, Fun 4}
+                                        Integer "Feature-260"
+                                                alternative
+                                                        Boolean "Feature-324" {Price 546}
+                                                        Boolean "Feature-460"
+                                                        Boolean "Feature-483"
+                                                                mandatory
+                                                                        Boolean "Feature-494"
+                                        Boolean "Feature-529" {Price 948}
+                        Boolean "Feature-123" cardinality [1..5] {Price 557}
+                                or
+                                        Integer "Feature-267"
+                                                optional
+                                                        Boolean "Feature-379" cardinality [1..5]
+                                                                alternative
+                                                                        Boolean "Feature-510" {Price 738, Fun -9}
+                                        Integer "Feature-456" cardinality [1..5]
+                        Boolean "Feature-130"
+                                mandatory
+                                        Boolean "Feature-151"
+                                                [2..3]
+                                                        Boolean "Feature-194"
+                                                                optional
+                                                                        Boolean "Feature-200"
+                                                                                [1..1]
+                                                                                        Boolean "Feature-240" cardinality [1..5] {Price 673}
+                                                                        Integer "Feature-209" {Price 476, Fun 28}
+                                                                                alternative
+                                                                                        Integer "Feature-252" cardinality [1..5]
+                                                                                        String "Feature-346" cardinality [1..5]
+                                                                        Boolean "Feature-269" cardinality [1..5] {Price 988}
+                                                                                optional
+                                                                                        Real "Feature-450"
+                                                                        Boolean "Feature-277" {Price 374}
+                                                                                [1..1]
+                                                                                        Boolean "Feature-493" {Price 524}
+                                                                        Boolean "Feature-409" {Price 762}
+                                                        Boolean "Feature-224" cardinality [1..5]
+                                                                alternative
+                                                                        Boolean "Feature-340"
+                                                                                alternative
+                                                                                        Boolean "Feature-364"
+                                                                                        Boolean "Feature-376" {Price 934, Fun 3}
+                                                        Boolean "Feature-367" {Price 309}
+                                        Boolean "Feature-281"
+
+constraints
+        "Feature-192" => "Feature-540" <=> "Feature-24" | !"Feature-451"
+        "Feature-178" & "Feature-281" => "Feature-203" | "Feature-150" <=> "Feature-328" | "Feature-180" & "Feature-218" <=> "Feature-172"
+        "Feature-249" <=> "Feature-435" <=> "Feature-234" => "Feature-479"
+        "Feature-396" == '1594003123'
+        len("Feature-392") == 410
+        "Feature-208".Price - "Feature-144".Price > "Feature-338".Price + "Feature-211".Fun * "Feature-37".Price
+        "Feature-413" => "Feature-378" | "Feature-514" <=> "Feature-301" <=> "Feature-542" <=> !"Feature-316"
+        "Feature-467" => "Feature-353" => "Feature-331" => "Feature-249" <=> "Feature-500" | "Feature-520" & "Feature-545" | "Feature-414" => "Feature-421" & "Feature-266" => "Feature-501" => "Feature-215"
+        "Feature-147" => "Feature-210" & "Feature-515" => "Feature-234" => !"Feature-254"
+        "Feature-444" <=> "Feature-520" <=> "Feature-383" & "Feature-377" <=> "Feature-461" | "Feature-376" <=> "Feature-249" => "Feature-316" => "Feature-412" & "Feature-435" & "Feature-362" <=> "Feature-349" => "Feature-442"
+        "Feature-172" <=> "Feature-506" => "Feature-313" & "Feature-522" | "Feature-447" | "Feature-471" & "Feature-462" => "Feature-215" & "Feature-23" <=> "Feature-386"
+        "Feature-331" => "Feature-66" <=> "Feature-83" & "Feature-201" & "Feature-78" <=> "Feature-514" <=> "Feature-373" & "Feature-349" & "Feature-162" <=> !"Feature-315"
+        "Feature-377" <=> "Feature-247" & "Feature-327" | "Feature-476" | "Feature-448" <=> "Feature-485" <=> "Feature-107" & "Feature-506"
+        "Feature-439" == '1490068914'
+        "Feature-460" <=> "Feature-223" | "Feature-221" & "Feature-542" => "Feature-545" => "Feature-284" <=> "Feature-496" <=> "Feature-131" <=> "Feature-311" => "Feature-328" | "Feature-285" | "Feature-478" | !"Feature-80"
+        "Feature-151" <=> "Feature-153" | !"Feature-94"
+        "Feature-514".Price * "Feature-545".Price + "Feature-264".Price != "Feature-466".Fun / "Feature-336".Price * "Feature-431".Price + "Feature-530".Price + "Feature-94".Price / "Feature-288".Price * "Feature-268".Price - "Feature-398".Fun - "Feature-527".Price
+        "Feature-497" | "Feature-108" | "Feature-352" | "Feature-140" => "Feature-266" => "Feature-508"
+        "Feature-337".Price * "Feature-530".Price / "Feature-118".Price * "Feature-70".Fun * "Feature-490".Price / "Feature-19".Fun + "Feature-209".Fun - "Feature-1".Price + "Feature-203".Price * "Feature-500".Price > "Feature-139".Fun / "Feature-519".Price * "Feature-78".Price
+        "Feature-441" & "Feature-123" & "Feature-63" <=> !"Feature-284"
+        "Feature-319" <=> "Feature-95" & "Feature-123" <=> "Feature-371" & "Feature-296" <=> "Feature-210" => !"Feature-1"
+        "Feature-237" == '2075025530'
+        sum(Fun) > -63
+        "Feature-311" => "Feature-177" <=> "Feature-41"
+        "Feature-138" | "Feature-220" | "Feature-178"
+        "Feature-498" == '-1478892423'
+        "Feature-505" | "Feature-483" & "Feature-323" => "Feature-214" <=> "Feature-286" <=> "Feature-408" <=> "Feature-527" & "Feature-13" & "Feature-26" <=> "Feature-173" => "Feature-515" & "Feature-44" | "Feature-175"
+        "Feature-523" => "Feature-303" => "Feature-349" <=> "Feature-505" <=> "Feature-485" | "Feature-53" => "Feature-231" <=> "Feature-10"
+        "Feature-255" => "Feature-155" <=> "Feature-489" <=> "Feature-27" | "Feature-331" <=> "Feature-98" <=> "Feature-462" & "Feature-364" & "Feature-276"
+        "Feature-311".Price * "Feature-315".Price / "Feature-342".Fun - "Feature-96".Price + "Feature-256".Price - "Feature-32".Price > "Feature-479".Fun / "Feature-161".Price / "Feature-209".Fun - "Feature-48".Price / "Feature-68".Price - "Feature-190".Price / "Feature-46".Price + "Feature-545".Price
+        "Feature-118" => "Feature-269" => "Feature-373" | "Feature-245" & "Feature-522" => "Feature-108" => "Feature-144" => "Feature-125" & "Feature-241" & "Feature-361" & "Feature-37" | "Feature-493" => "Feature-386"
+        "Feature-187" | "Feature-242" => "Feature-373" => "Feature-407" & "Feature-160" | "Feature-393" => "Feature-515"
+        "Feature-354" <=> "Feature-44" | "Feature-412" & !"Feature-474"
+        "Feature-505" <=> "Feature-377" => "Feature-467" <=> "Feature-311" | "Feature-201" => "Feature-144" <=> "Feature-412" <=> "Feature-503" & "Feature-131" | "Feature-165" <=> "Feature-194" & "Feature-476" <=> "Feature-271" & !"Feature-309"
+        "Feature-24" | "Feature-225" | "Feature-98" => "Feature-361" => "Feature-245" => !"Feature-78"
+        "Feature-305" <=> "Feature-246" & "Feature-263" => "Feature-83" | "Feature-353" => "Feature-497" | "Feature-451" => "Feature-250"
+        "Feature-287".Fun / "Feature-493".Price - "Feature-53".Price - "Feature-173".Price - "Feature-414".Price > "Feature-147".Fun + "Feature-104".Price - "Feature-503".Fun / "Feature-420".Price * "Feature-63".Price * "Feature-542".Price + "Feature-89".Price
+        "Feature-140" | "Feature-345" <=> "Feature-74" | "Feature-51" | "Feature-474" & "Feature-362" <=> "Feature-221" <=> "Feature-303" => "Feature-378"
+        "Feature-234" <=> "Feature-198" & "Feature-502" & "Feature-74" | "Feature-482" | "Feature-205" => "Feature-427" => "Feature-531" => "Feature-541" => "Feature-8" => "Feature-220" => "Feature-147" | !"Feature-337"
+        "Feature-328".Fun > "Feature-5".Price * "Feature-409".Price * "Feature-242".Price + "Feature-414".Price * "Feature-250".Price + "Feature-328".Fun
+        "Feature-230" => "Feature-337" => "Feature-163" | "Feature-477" <=> "Feature-151" <=> "Feature-353" & "Feature-2" <=> "Feature-276" => "Feature-309" => "Feature-362" => !"Feature-339"
+        "Feature-315" => "Feature-31" & "Feature-471" & "Feature-549" <=> "Feature-37" & "Feature-469" | "Feature-123" & "Feature-328" => "Feature-44"
+        avg(Price) > 4517
+        "Feature-531" | "Feature-134" => "Feature-163" | !"Feature-311"
+        "Feature-318" <=> "Feature-187" | "Feature-448" <=> "Feature-149" <=> "Feature-522" | "Feature-223" <=> "Feature-34" & "Feature-325" <=> !"Feature-192"
+        "Feature-485" => "Feature-240" => "Feature-480" | "Feature-179" <=> "Feature-223" <=> "Feature-48" => "Feature-386" & "Feature-334" => "Feature-545" => "Feature-540" <=> "Feature-193" => "Feature-276" | "Feature-448" <=> "Feature-302"
+        "Feature-535" | "Feature-0"
+        "Feature-392" == '-751303675'
+        "Feature-40" <=> "Feature-175" & "Feature-279" & "Feature-520" <=> "Feature-430" | "Feature-150" <=> "Feature-489" => "Feature-296"
+        "Feature-88" => "Feature-546" <=> "Feature-441" <=> "Feature-505" & "Feature-7" <=> "Feature-435" & "Feature-442" => "Feature-325" => "Feature-231" <=> "Feature-29" => "Feature-274" => "Feature-300" <=> "Feature-535"
+        len("Feature-170") == 938
+        "Feature-224" | "Feature-89" => "Feature-493" <=> "Feature-422" => "Feature-473" | "Feature-29" & "Feature-362" => "Feature-95" <=> "Feature-502" | "Feature-488" & "Feature-153" => "Feature-129" | "Feature-364"
+        "Feature-40" | "Feature-173" => "Feature-241"
+        "Feature-300" => "Feature-326" <=> "Feature-18" | "Feature-542" | "Feature-360" <=> "Feature-425" & !"Feature-40"
+        "Feature-272" & "Feature-29" => "Feature-289" => "Feature-172"
+        "Feature-81".Price + "Feature-172".Price * "Feature-66".Price < "Feature-513".Price
+        "Feature-200" => "Feature-247" & "Feature-500" <=> !"Feature-364"
+        "Feature-497" => "Feature-242" <=> "Feature-266" <=> "Feature-120" & "Feature-459" <=> "Feature-423" & "Feature-244" & "Feature-32" | "Feature-473" => "Feature-474" => "Feature-8" | "Feature-309" | !"Feature-40"
+        "Feature-527" | "Feature-55" => "Feature-349" & "Feature-271" | "Feature-63" => "Feature-224" & "Feature-461" => "Feature-7" & "Feature-172" <=> "Feature-313" => "Feature-467" | "Feature-215"
+        len("Feature-35") == 157
+        "Feature-105" => "Feature-289" | "Feature-247" => "Feature-384" => "Feature-503" & "Feature-353" | "Feature-404" & "Feature-377"
+        "Feature-542" => "Feature-94" <=> "Feature-130" => "Feature-325" | "Feature-276" <=> "Feature-545" => "Feature-357" & "Feature-489" <=> "Feature-435" <=> "Feature-491" | "Feature-165"
+        "Feature-97" => "Feature-176" & "Feature-503" <=> "Feature-496" => "Feature-444"
+        "Feature-504" | "Feature-304" => "Feature-324" & "Feature-350" & "Feature-210" <=> "Feature-0"
+        "Feature-194" & !"Feature-503"
+        sum(Fun) > 19
+        "Feature-496" => "Feature-172" & "Feature-136"
+        "Feature-138" => "Feature-357" => "Feature-323" <=> "Feature-224" | "Feature-193" & "Feature-326" | "Feature-176" | "Feature-175" => "Feature-363" => "Feature-240" => "Feature-514" | "Feature-53" | "Feature-88" | !"Feature-327"
+        "Feature-527" <=> "Feature-28" & "Feature-460" & "Feature-362" => "Feature-514" => "Feature-467" | "Feature-502" | "Feature-33" & "Feature-2" & "Feature-305" => "Feature-316"
+        "Feature-409" <=> "Feature-250" <=> "Feature-29" => "Feature-421" <=> "Feature-80" => "Feature-162" | "Feature-130"
+        "Feature-269".Price - "Feature-431".Price / "Feature-214".Price * "Feature-276".Price < "Feature-116".Fun
+        "Feature-471" => "Feature-3" | "Feature-34" <=> "Feature-349" => "Feature-187" | "Feature-493" <=> "Feature-211" | !"Feature-182"
+        "Feature-8" => "Feature-542" & "Feature-112" => "Feature-110" & "Feature-364" & "Feature-286" | "Feature-130" <=> "Feature-131" | "Feature-68"
+        "Feature-141" <=> "Feature-48" <=> "Feature-303" | "Feature-298" <=> "Feature-231" <=> "Feature-129" | "Feature-214" => "Feature-53" => "Feature-514" & "Feature-408" <=> "Feature-312" <=> "Feature-409"
+        "Feature-13" <=> "Feature-408" <=> "Feature-241" | "Feature-361" & "Feature-96" & "Feature-177" | "Feature-345" & !"Feature-211"

--- a/test_resources/parsing/generated/fm3.uvl
+++ b/test_resources/parsing/generated/fm3.uvl
@@ -1,0 +1,847 @@
+features
+        Boolean "Feature-0"
+                optional
+                        Integer "Feature-1" {Price 736}
+                                [6..12]
+                                        Boolean "Feature-3" {Price 828}
+                                                alternative
+                                                        Boolean "Feature-6" cardinality [1..5] {Price 157}
+                                                                or
+                                                                        Boolean "Feature-15" {Price 651}
+                                                                                optional
+                                                                                        String "Feature-134" {Price 380}
+                                                                                        Boolean "Feature-156" cardinality [1..5] {Price 106, Fun 94}
+                                                                                        Boolean "Feature-316"
+                                                                        Boolean "Feature-71" {Price 584}
+                                                                                mandatory
+                                                                                        Boolean "Feature-97" {Price 960, Fun -42}
+                                                                                        Boolean "Feature-111"
+                                                                                        Integer "Feature-176" cardinality [1..5]
+                                                                        Integer "Feature-96"
+                                                                                [0..1]
+                                                                                        Boolean "Feature-241"
+                                                                        Integer "Feature-209"
+                                                                                or
+                                                                                        Boolean "Feature-380" {Price 313, Fun 15}
+                                                                                        String "Feature-514" {Price 467}
+                                                                        Integer "Feature-258"
+                                                                                [1..1]
+                                                                                        Boolean "Feature-277" {Price 551}
+                                                                                        Boolean "Feature-381"
+                                                                        Boolean "Feature-364" {Fun 32}
+                                                                        String "Feature-438" {Price 174}
+                                                        Boolean "Feature-45"
+                                                                mandatory
+                                                                        Boolean "Feature-51" cardinality [1..5] {Price 987}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-205" {Price 626}
+                                                                                        String "Feature-412"
+                                                                                        Integer "Feature-546" cardinality [1..5] {Price 746}
+                                                                        Boolean "Feature-56" cardinality [1..5]
+                                                                                [0..1]
+                                                                                        Boolean "Feature-373"
+                                                                        Integer "Feature-91"
+                                                                                optional
+                                                                                        Boolean "Feature-340"
+                                                                        Integer "Feature-105"
+                                                                                or
+                                                                                        Boolean "Feature-397"
+                                                                                        Boolean "Feature-498" cardinality [1..5] {Price 732}
+                                                                        Integer "Feature-323"
+                                                                                alternative
+                                                                                        Boolean "Feature-359" cardinality [1..5]
+                                                                                        Boolean "Feature-375"
+                                                                                        Boolean "Feature-481" cardinality [1..5] {Price 602}
+                                                        Boolean "Feature-102" {Price 886}
+                                                                mandatory
+                                                                        Boolean "Feature-247"
+                                                                                or
+                                                                                        String "Feature-480" cardinality [1..5]
+                                                                                        Integer "Feature-510"
+                                                        Integer "Feature-106"
+                                                                mandatory
+                                                                        Boolean "Feature-138"
+                                                                        Boolean "Feature-502" {Price 673}
+                                                        Boolean "Feature-175" {Price 784}
+                                                        Boolean "Feature-341"
+                                        Boolean "Feature-4" {Price 317}
+                                                [2..2]
+                                                        Integer "Feature-7" {Price 472}
+                                                                alternative
+                                                                        Boolean "Feature-24" {Price 407}
+                                                                                alternative
+                                                                                        Integer "Feature-123"
+                                                                                        Boolean "Feature-145" {Price 681}
+                                                                                        Boolean "Feature-263" {Price 51}
+                                                                                        Integer "Feature-492"
+                                                                        Integer "Feature-37"
+                                                                                [4..4]
+                                                                                        Boolean "Feature-82" cardinality [1..5] {Price 445}
+                                                                                        Boolean "Feature-196" {Price 258}
+                                                                                        Boolean "Feature-206"
+                                                                                        Integer "Feature-298"
+                                                                                        Integer "Feature-311" {Price 463}
+                                                                        Boolean "Feature-160"
+                                                                        Boolean "Feature-363" {Price 687}
+                                                                        Boolean "Feature-449"
+                                                                        Boolean "Feature-484" cardinality [1..5] {Price 469}
+                                                        Boolean "Feature-10"
+                                                                mandatory
+                                                                        Boolean "Feature-41" cardinality [1..5]
+                                                                                alternative
+                                                                                        Real "Feature-47" {Price 60, Fun 4}
+                                                                                        Boolean "Feature-114" {Price 465}
+                                                                                        Integer "Feature-297" {Price 805}
+                                                                                        Integer "Feature-402" {Price 618}
+                                                                                        String "Feature-489" {Price 760}
+                                                                        Boolean "Feature-49" {Price 25}
+                                                                                [2..2]
+                                                                                        String "Feature-135" {Price 836, Fun 22}
+                                                                                        Boolean "Feature-294" {Price 905}
+                                                                        Boolean "Feature-129" {Price 452}
+                                                                                [2..4]
+                                                                                        Integer "Feature-182" {Price 375}
+                                                                                        Integer "Feature-408" cardinality [1..5] {Price 892, Fun 61}
+                                                                                        Real "Feature-422" {Price 448}
+                                                                                        Boolean "Feature-455"
+                                                                        Boolean "Feature-225" cardinality [1..5] {Fun 10}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-496" {Price 393}
+                                                                        Integer "Feature-344" {Price 67}
+                                                                                alternative
+                                                                                        Integer "Feature-448" {Price 540, Fun 67}
+                                                                                        Boolean "Feature-509" {Fun -7}
+                                                                                        Boolean "Feature-516" {Price 909}
+                                                                        Boolean "Feature-459" {Price 184}
+                                                        Integer "Feature-20" {Price 385}
+                                                                or
+                                                                        Boolean "Feature-66"
+                                                                        Real "Feature-144" {Price 319}
+                                                                        Boolean "Feature-170" {Price 316, Fun -13}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-181"
+                                                                        Boolean "Feature-197"
+                                                                        Boolean "Feature-281"
+                                                                                alternative
+                                                                                        Boolean "Feature-365" {Price 565}
+                                                                        Boolean "Feature-378" {Price 359}
+                                                                        Boolean "Feature-472"
+                                                                                or
+                                                                                        Boolean "Feature-473" {Price 163, Fun -46}
+                                                        Boolean "Feature-125"
+                                                                alternative
+                                                                        Boolean "Feature-377" {Price 888}
+                                                                                or
+                                                                                        Boolean "Feature-474" {Price 378}
+                                                                        String "Feature-393"
+                                                        Boolean "Feature-506" cardinality [1..5]
+                                        Boolean "Feature-8"
+                                                mandatory
+                                                        Boolean "Feature-11" {Price 642}
+                                                                mandatory
+                                                                        String "Feature-18" {Price 926}
+                                                                                alternative
+                                                                                        Boolean "Feature-108"
+                                                                                        Integer "Feature-301"
+                                                                                        String "Feature-382"
+                                                                                        Boolean "Feature-436" {Price 253}
+                                                                        Boolean "Feature-21" {Price 592}
+                                                                                optional
+                                                                                        Integer "Feature-151" {Price 779}
+                                                                        String "Feature-63" {Price 632, Fun 74}
+                                                                                optional
+                                                                                        Boolean "Feature-257"
+                                                                        Real "Feature-171"
+                                                                                [2..2]
+                                                                                        Boolean "Feature-259" {Price 653}
+                                                                                        Integer "Feature-501"
+                                                                        Boolean "Feature-186" cardinality [1..5] {Price 96}
+                                                                                or
+                                                                                        Boolean "Feature-189"
+                                                                                        Integer "Feature-295" {Price 876}
+                                                                        Boolean "Feature-349" cardinality [1..5] {Fun -29}
+                                                                        Boolean "Feature-478" {Price 809}
+                                                        Boolean "Feature-12"
+                                                                mandatory
+                                                                        Integer "Feature-46" {Fun 4}
+                                                                                mandatory
+                                                                                        Integer "Feature-204" {Price 126}
+                                                                                        Boolean "Feature-310"
+                                                                        Boolean "Feature-68" {Price 645}
+                                                                                optional
+                                                                                        Boolean "Feature-88" {Price 17}
+                                                                                        Integer "Feature-118" {Price 30}
+                                                                                        Real "Feature-203" {Price 111}
+                                                                                        Integer "Feature-401" {Price 830, Fun -47}
+                                                                        Boolean "Feature-73"
+                                                                                alternative
+                                                                                        Boolean "Feature-238" {Price 385}
+                                                                                        Boolean "Feature-317"
+                                                                                        Boolean "Feature-541"
+                                                                        Integer "Feature-164"
+                                                        Integer "Feature-13"
+                                                                mandatory
+                                                                        Real "Feature-16" {Price 327}
+                                                                                mandatory
+                                                                                        String "Feature-77" cardinality [1..5] {Price 326}
+                                                                                        Integer "Feature-149"
+                                                                                        Boolean "Feature-217"
+                                                                                        Boolean "Feature-269" {Price 402}
+                                                                        Boolean "Feature-17" {Price 266, Fun 95}
+                                                                                alternative
+                                                                                        String "Feature-25" {Fun -93}
+                                                                                        Boolean "Feature-42"
+                                                                                        Integer "Feature-93" {Fun -35}
+                                                                                        Boolean "Feature-168" {Price 475}
+                                                                                        Boolean "Feature-235"
+                                                                        Real "Feature-119" cardinality [1..5] {Fun -44}
+                                                                                optional
+                                                                                        Boolean "Feature-141" {Fun -35}
+                                                                                        Boolean "Feature-270"
+                                                                                        Boolean "Feature-284" {Price 591, Fun -36}
+                                                                        Boolean "Feature-388" cardinality [1..5] {Price 968}
+                                                                                alternative
+                                                                                        Boolean "Feature-476" {Price 992}
+                                                        Boolean "Feature-27" {Price 237, Fun 97}
+                                                                optional
+                                                                        Boolean "Feature-32"
+                                                                                [0..1]
+                                                                                        Integer "Feature-89" {Price 183}
+                                                                        Boolean "Feature-44" cardinality [1..5] {Price 864}
+                                                                                [2..2]
+                                                                                        Boolean "Feature-55" cardinality [1..5] {Price 564}
+                                                                                        Real "Feature-500" {Price 333}
+                                                                        Integer "Feature-59" {Price 667}
+                                                                                or
+                                                                                        Boolean "Feature-154"
+                                                                                        Boolean "Feature-307" {Price 360}
+                                                                        Boolean "Feature-112"
+                                                                                or
+                                                                                        Boolean "Feature-219" {Fun -19}
+                                                                        Integer "Feature-188"
+                                                                                alternative
+                                                                                        Boolean "Feature-252" {Price 595}
+                                                        Boolean "Feature-28"
+                                                                alternative
+                                                                        Boolean "Feature-75"
+                                                                                or
+                                                                                        Integer "Feature-278"
+                                                                                        Boolean "Feature-494" {Price 319}
+                                                                        Boolean "Feature-128" {Price 952}
+                                                                                alternative
+                                                                                        Boolean "Feature-289" {Price 207}
+                                                                        String "Feature-223" {Price 435}
+                                                                                mandatory
+                                                                                        Real "Feature-446"
+                                                        Boolean "Feature-116" {Price 336}
+                                                                or
+                                                                        Boolean "Feature-227" cardinality [1..5] {Price 921}
+                                                                                or
+                                                                                        Boolean "Feature-330" {Price 640}
+                                                                        Integer "Feature-274" {Price 288}
+                                                                        Integer "Feature-483"
+                                                                        String "Feature-508" cardinality [1..5] {Price 639}
+                                                        Boolean "Feature-153" {Price 835}
+                                                        Boolean "Feature-315" {Price 982}
+                                                                mandatory
+                                                                        Integer "Feature-549"
+                                        Integer "Feature-33" {Price 144}
+                                                alternative
+                                                        Boolean "Feature-406"
+                                        Boolean "Feature-43" {Price 394}
+                                                or
+                                                        Integer "Feature-60" {Price 214}
+                                                                alternative
+                                                                        Integer "Feature-80"
+                                                                                alternative
+                                                                                        Boolean "Feature-140" {Fun -37}
+                                                                                        Boolean "Feature-147"
+                                                                                        Integer "Feature-253" {Price 466}
+                                                                                        String "Feature-389"
+                                                                                        Boolean "Feature-442" {Price 174}
+                                                                        String "Feature-157"
+                                                                                [1..1]
+                                                                                        Boolean "Feature-342"
+                                                                        Boolean "Feature-264" {Price 46}
+                                                        Boolean "Feature-62" {Price 670}
+                                                                optional
+                                                                        Integer "Feature-64"
+                                                                                mandatory
+                                                                                        Boolean "Feature-85" cardinality [1..5] {Price 801}
+                                                                                        Boolean "Feature-139" {Price 542}
+                                                                                        Boolean "Feature-429" {Price 272}
+                                                                        Boolean "Feature-185" {Fun -81}
+                                                                                or
+                                                                                        Boolean "Feature-228"
+                                                                                        Boolean "Feature-290"
+                                                                        Integer "Feature-271" cardinality [1..5] {Price 854}
+                                                                                alternative
+                                                                                        Boolean "Feature-392"
+                                                        Boolean "Feature-178" cardinality [1..5]
+                                                                alternative
+                                                                        Boolean "Feature-190" cardinality [1..5]
+                                                                                mandatory
+                                                                                        Boolean "Feature-233" {Price 92}
+                                                                                        Boolean "Feature-255"
+                                                                                        Boolean "Feature-513"
+                                                                                        Boolean "Feature-547"
+                                                                        Integer "Feature-231" {Price 872}
+                                                                                or
+                                                                                        Real "Feature-262"
+                                                                                        Boolean "Feature-362" {Price 691}
+                                                                        Boolean "Feature-420" {Price 778}
+                                                                                alternative
+                                                                                        Real "Feature-451" {Price 153}
+                                                        Integer "Feature-192"
+                                                                [2..2]
+                                                                        Real "Feature-260" {Price 328}
+                                                                        Boolean "Feature-266"
+                                                                        Boolean "Feature-443" {Price 168}
+                                                                                mandatory
+                                                                                        Integer "Feature-487"
+                                                        Boolean "Feature-347" {Price 800}
+                                        Boolean "Feature-50" {Price 718}
+                                                [1..1]
+                                                        Boolean "Feature-94" {Price 782}
+                                                                alternative
+                                                                        Boolean "Feature-136"
+                                                                                [0..1]
+                                                                                        Boolean "Feature-439" {Price 680}
+                                                                        String "Feature-169"
+                                                                                or
+                                                                                        Boolean "Feature-293" {Fun 8}
+                                                                        Boolean "Feature-367"
+                                                                                alternative
+                                                                                        Boolean "Feature-410" {Price 657}
+                                                                                        Real "Feature-421" cardinality [1..5] {Price 868}
+                                                                                        Boolean "Feature-427"
+                                                                                        Boolean "Feature-482"
+                                                        Boolean "Feature-133" cardinality [1..5] {Fun 60}
+                                                                alternative
+                                                                        Integer "Feature-470"
+                                                                                alternative
+                                                                                        Boolean "Feature-518"
+                                                                                        Integer "Feature-532" {Price 363, Fun 9}
+                                        Boolean "Feature-57"
+                                                mandatory
+                                                        Real "Feature-159" {Price 790}
+                                                                [0..1]
+                                                                        Boolean "Feature-214"
+                                                        Boolean "Feature-240" {Price 426, Fun -85}
+                                                                or
+                                                                        Boolean "Feature-445"
+                                                        Boolean "Feature-288" {Fun 98}
+                                                                alternative
+                                                                        Boolean "Feature-447" {Price 107}
+                                                                                [1..1]
+                                                                                        Boolean "Feature-461"
+                                                                        Boolean "Feature-519"
+                                                        Integer "Feature-424" cardinality [1..5]
+                                                                optional
+                                                                        Boolean "Feature-450" {Fun -94}
+                                        Real "Feature-61"
+                                                [3..4]
+                                                        Boolean "Feature-83"
+                                                                alternative
+                                                                        Boolean "Feature-142" {Price 319}
+                                                                                or
+                                                                                        Boolean "Feature-243" {Price 830}
+                                                                                        Boolean "Feature-400"
+                                                                                        Boolean "Feature-464"
+                                                                                        Boolean "Feature-548" {Price 725}
+                                                                        Boolean "Feature-250"
+                                                                        Integer "Feature-358"
+                                                                                optional
+                                                                                        Boolean "Feature-528"
+                                                        Boolean "Feature-90"
+                                                                mandatory
+                                                                        Boolean "Feature-146" {Price 585}
+                                                                        Boolean "Feature-490" {Price 925}
+                                                        Boolean "Feature-95"
+                                                        Boolean "Feature-208"
+                                                                optional
+                                                                        Boolean "Feature-239"
+                                                                                alternative
+                                                                                        Boolean "Feature-242" {Price 752}
+                                                                                        Integer "Feature-485"
+                                                                        Integer "Feature-354" cardinality [1..5]
+                                                                        Boolean "Feature-372"
+                                        Boolean "Feature-76" cardinality [1..5] {Price 142, Fun 57}
+                                        Real "Feature-184"
+                                                alternative
+                                                        Boolean "Feature-198" {Price 140}
+                                                                alternative
+                                                                        Boolean "Feature-215"
+                                                                                optional
+                                                                                        Boolean "Feature-533" {Fun 9}
+                                                                        Boolean "Feature-229" {Price 186}
+                                                                                mandatory
+                                                                                        Real "Feature-300"
+                                                                        Boolean "Feature-326"
+                                                        Boolean "Feature-302" {Price 445}
+                                                                [1..1]
+                                                                        Boolean "Feature-308" cardinality [1..5] {Price 645}
+                                                                                or
+                                                                                        String "Feature-493" {Price 366}
+                                                        Boolean "Feature-530" {Price 377}
+                                        Boolean "Feature-224"
+                                        String "Feature-236"
+                                        Boolean "Feature-369"
+                                        Boolean "Feature-466"
+                        Real "Feature-2" {Price 874}
+                                or
+                                        Boolean "Feature-5" {Price 475}
+                                                alternative
+                                                        Boolean "Feature-174" cardinality [1..5]
+                                                                alternative
+                                                                        String "Feature-324" {Price 300}
+                                                                                optional
+                                                                                        Integer "Feature-437" cardinality [1..5]
+                                                                        Boolean "Feature-456" {Fun 10}
+                                                                        Boolean "Feature-486" {Price 137}
+                                                        Boolean "Feature-395"
+                                                        Boolean "Feature-426" {Price 605}
+                                        Integer "Feature-26"
+                                                optional
+                                                        Boolean "Feature-72"
+                                                                alternative
+                                                                        Boolean "Feature-131" {Price 377}
+                                                                                or
+                                                                                        Boolean "Feature-179"
+                                                                                        Boolean "Feature-199"
+                                                                        Boolean "Feature-191"
+                                                                                or
+                                                                                        Real "Feature-276" {Price 657}
+                                                                                        Boolean "Feature-309" {Price 842}
+                                                                                        Boolean "Feature-318" {Price 105}
+                                                        Integer "Feature-193" {Price 491}
+                                                                or
+                                                                        Boolean "Feature-333" {Price 542}
+                                                                                optional
+                                                                                        Integer "Feature-338"
+                                                                                        Integer "Feature-465" {Price 302}
+                                                        Boolean "Feature-545"
+                                        Boolean "Feature-31" {Price 751}
+                                                alternative
+                                                        Boolean "Feature-35"
+                                                                [1..1]
+                                                                        Boolean "Feature-65"
+                                                                                [0..2]
+                                                                                        Real "Feature-216" {Price 290}
+                                                                                        String "Feature-251" cardinality [1..5]
+                                                                        Boolean "Feature-296" {Price 290}
+                                                        Boolean "Feature-52" {Price 863}
+                                                                optional
+                                                                        Boolean "Feature-104" {Price 754}
+                                                                                mandatory
+                                                                                        Boolean "Feature-335" cardinality [1..5] {Price 96}
+                                                                                        String "Feature-404"
+                                                                                        Boolean "Feature-409" {Price 895}
+                                                                        Boolean "Feature-312" {Price 392}
+                                                                                or
+                                                                                        Boolean "Feature-522" {Price 405}
+                                                        Boolean "Feature-53"
+                                                                or
+                                                                        Boolean "Feature-322"
+                                                                                mandatory
+                                                                                        Boolean "Feature-503"
+                                                                        Integer "Feature-370" cardinality [1..5] {Price 986}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-441"
+                                                                        Integer "Feature-479" {Price 640}
+                                                        Boolean "Feature-148"
+                                                                optional
+                                                                        Boolean "Feature-374"
+                                                                                or
+                                                                                        Boolean "Feature-511"
+                                                        Boolean "Feature-213"
+                                                        Boolean "Feature-314"
+                                                                [0..1]
+                                                                        Boolean "Feature-334"
+                                                        Boolean "Feature-418"
+                                                                optional
+                                                                        Boolean "Feature-463" {Price 859}
+                                        Integer "Feature-36" {Price 302}
+                                                or
+                                                        Integer "Feature-101" {Price 811}
+                                                                mandatory
+                                                                        Boolean "Feature-173"
+                                                                                or
+                                                                                        Boolean "Feature-177" {Price 817, Fun -62}
+                                                                        Boolean "Feature-211"
+                                                                                mandatory
+                                                                                        Integer "Feature-477" {Price 383}
+                                                                        Boolean "Feature-524" {Price 113}
+                                                        Boolean "Feature-336"
+                                                                alternative
+                                                                        Boolean "Feature-428" cardinality [1..5]
+                                                        Boolean "Feature-371"
+                                                                mandatory
+                                                                        Integer "Feature-460" {Fun -13}
+                                                        Boolean "Feature-515" cardinality [1..5]
+                                                        Integer "Feature-534"
+                                        Boolean "Feature-48" cardinality [1..5] {Fun 59}
+                                        Boolean "Feature-107"
+                                                optional
+                                                        Boolean "Feature-407" cardinality [1..5] {Fun 94}
+                                                        Boolean "Feature-525"
+                        Integer "Feature-9" {Price 680}
+                                or
+                                        Boolean "Feature-19"
+                                                alternative
+                                                        Boolean "Feature-396" cardinality [1..5]
+                                        Integer "Feature-22"
+                                                mandatory
+                                                        Boolean "Feature-30"
+                                                                mandatory
+                                                                        Integer "Feature-40" cardinality [1..5]
+                                                                                [0..1]
+                                                                                        String "Feature-54" cardinality [1..5]
+                                                                                        Integer "Feature-67" cardinality [1..5] {Price 809}
+                                                                                        Boolean "Feature-162" cardinality [1..5]
+                                                                                        Boolean "Feature-226"
+                                                                                        Boolean "Feature-376"
+                                                                        Boolean "Feature-187" cardinality [1..5]
+                                                                                alternative
+                                                                                        String "Feature-390" {Price 322}
+                                                                        Boolean "Feature-517" {Price 927}
+                                                        Integer "Feature-100"
+                                                                [2..3]
+                                                                        Boolean "Feature-234"
+                                                                        Boolean "Feature-246" cardinality [1..5]
+                                                                        Integer "Feature-431" {Fun -27}
+                                                                                alternative
+                                                                                        Boolean "Feature-507" cardinality [1..5]
+                                                                        Boolean "Feature-458"
+                                                                        Boolean "Feature-539" {Price 904}
+                                                        Boolean "Feature-121"
+                                                                [2..3]
+                                                                        Boolean "Feature-356"
+                                                                        Boolean "Feature-361" {Price 836}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-432" {Price 741}
+                                                                        Boolean "Feature-457" cardinality [1..5]
+                                                                                mandatory
+                                                                                        Boolean "Feature-529"
+                                                        Integer "Feature-124" {Price 230}
+                                                                or
+                                                                        Boolean "Feature-137" {Price 579, Fun -82}
+                                                                                mandatory
+                                                                                        Boolean "Feature-304" {Fun 73}
+                                                                                        Boolean "Feature-453"
+                                                                        Integer "Feature-158"
+                                                                        Boolean "Feature-245"
+                                                                        Boolean "Feature-353" cardinality [1..5] {Price 245}
+                                                                                or
+                                                                                        Integer "Feature-537" {Price 660}
+                                                        Boolean "Feature-161"
+                                                                [0..1]
+                                                                        Boolean "Feature-267"
+                                        Boolean "Feature-58" {Price 539}
+                                                mandatory
+                                                        Boolean "Feature-155" {Price 927}
+                                                                [1..2]
+                                                                        Boolean "Feature-254" cardinality [1..5]
+                                                                                or
+                                                                                        Boolean "Feature-279" cardinality [1..5]
+                                                                        Boolean "Feature-454" {Price 833}
+                                                                                or
+                                                                                        Boolean "Feature-526"
+                                                        Boolean "Feature-386" {Price 195}
+                                                                or
+                                                                        Boolean "Feature-468" {Price 289}
+                                                        Integer "Feature-399"
+                                        String "Feature-87" {Price 693}
+                                                [0..2]
+                                                        Boolean "Feature-113" {Price 235}
+                                                                alternative
+                                                                        Boolean "Feature-117"
+                                                                                alternative
+                                                                                        Boolean "Feature-332"
+                                                                                        String "Feature-540"
+                                                                        Boolean "Feature-127" {Price 288}
+                                                                                [3..4]
+                                                                                        Boolean "Feature-244" {Price 828}
+                                                                                        String "Feature-306"
+                                                                                        Integer "Feature-328" {Price 23}
+                                                                                        Real "Feature-357" cardinality [1..5]
+                                                                        Boolean "Feature-237" cardinality [1..5] {Price 976}
+                                                                                or
+                                                                                        Boolean "Feature-313" {Price 820}
+                                                                        Boolean "Feature-467" cardinality [1..5] {Price 702}
+                                                                                alternative
+                                                                                        Boolean "Feature-504"
+                                                        Boolean "Feature-220" cardinality [1..5] {Price 743}
+                                                        Boolean "Feature-331" {Price 883}
+                                        Boolean "Feature-180" {Price 458}
+                                                [1..1]
+                                                        Integer "Feature-202" {Price 48}
+                                                                or
+                                                                        Boolean "Feature-343"
+                                                                                [1..1]
+                                                                                        Real "Feature-350" cardinality [1..5] {Price 41}
+                                        Boolean "Feature-218"
+                        Boolean "Feature-14" {Price 308, Fun -97}
+                                or
+                                        Boolean "Feature-84"
+                                                mandatory
+                                                        Integer "Feature-132"
+                                                                or
+                                                                        Boolean "Feature-150"
+                                                                        Boolean "Feature-512" {Price 784}
+                                                        Boolean "Feature-166"
+                                                        Boolean "Feature-535" {Price 68}
+                                        Boolean "Feature-99" {Price 844}
+                                        Integer "Feature-103" {Price 412}
+                                                or
+                                                        Boolean "Feature-120"
+                                                                [0..2]
+                                                                        Boolean "Feature-152" {Price 550}
+                                                                        Boolean "Feature-351" cardinality [1..5] {Price 353}
+                                                        Real "Feature-130" cardinality [1..5]
+                                                                mandatory
+                                                                        String "Feature-167"
+                                                                                alternative
+                                                                                        Integer "Feature-462"
+                                                                        Boolean "Feature-287" {Price 788}
+                                                                                or
+                                                                                        Boolean "Feature-430" {Fun 60}
+                                                                        Boolean "Feature-505" {Price 429}
+                                                        Boolean "Feature-195" cardinality [1..5] {Price 817}
+                                                                mandatory
+                                                                        Boolean "Feature-221" {Price 13}
+                                                                                [1..3]
+                                                                                        Integer "Feature-232" cardinality [1..5]
+                                                                                        Boolean "Feature-256" {Price 650}
+                                                                                        Boolean "Feature-327"
+                                                                        Integer "Feature-348" {Price 798}
+                                                                                mandatory
+                                                                                        Integer "Feature-368" {Price 652}
+                                                                        Boolean "Feature-434"
+                                                                        Integer "Feature-475" cardinality [1..5] {Price 162}
+                                                        Integer "Feature-248"
+                                                                [1..1]
+                                                                        Boolean "Feature-387" {Price 763}
+                                                                                mandatory
+                                                                                        String "Feature-391" cardinality [1..5] {Price 193}
+                                                        Integer "Feature-419"
+                                                                [1..1]
+                                                                        Boolean "Feature-497" {Price 895, Fun 31}
+                                        Boolean "Feature-163"
+                                        Integer "Feature-471" cardinality [1..5]
+                        Boolean "Feature-23" cardinality [1..5] {Price 724}
+                                mandatory
+                                        Boolean "Feature-29" cardinality [1..5] {Price 249}
+                                                alternative
+                                                        Boolean "Feature-165"
+                                                                mandatory
+                                                                        Boolean "Feature-352" {Price 873}
+                                                        Boolean "Feature-268" cardinality [1..5]
+                                                        Real "Feature-345" cardinality [1..5] {Price 127, Fun 26}
+                                                        Integer "Feature-403" {Price 821, Fun 5}
+                                                        Boolean "Feature-523" {Price 599}
+                                        Boolean "Feature-74" {Price 466}
+                                                or
+                                                        Boolean "Feature-183" cardinality [1..5]
+                                                        Boolean "Feature-222" {Price 374}
+                                                        Boolean "Feature-469" {Price 448}
+                                        Integer "Feature-110" cardinality [1..5] {Price 970}
+                                                or
+                                                        Integer "Feature-122"
+                                                                optional
+                                                                        Integer "Feature-355" cardinality [1..5] {Price 929}
+                                                        Integer "Feature-272"
+                                                                or
+                                                                        Integer "Feature-319"
+                                                                        Integer "Feature-491" {Price 69}
+                                                                                alternative
+                                                                                        Boolean "Feature-544"
+                                                        Boolean "Feature-285" {Price 82}
+                                        Boolean "Feature-495" cardinality [1..5]
+                        Integer "Feature-34" {Price 140}
+                                [1..3]
+                                        Boolean "Feature-38" {Price 138}
+                                                or
+                                                        Boolean "Feature-79" {Price 251}
+                                                                alternative
+                                                                        Boolean "Feature-92" {Price 535, Fun 15}
+                                                                                or
+                                                                                        Boolean "Feature-200"
+                                                                                        Boolean "Feature-291" {Fun -29}
+                                                                        Boolean "Feature-98" cardinality [1..5] {Price 304}
+                                                                                [1..1]
+                                                                                        Boolean "Feature-194"
+                                                                        String "Feature-337" {Price 779}
+                                                                                mandatory
+                                                                                        Boolean "Feature-384"
+                                                        Integer "Feature-81" cardinality [1..5] {Price 38}
+                                                                optional
+                                                                        Boolean "Feature-416"
+                                                                        Integer "Feature-531"
+                                                        Boolean "Feature-230" {Price 795}
+                                                                or
+                                                                        Boolean "Feature-249"
+                                                                                or
+                                                                                        Boolean "Feature-488"
+                                                                        Boolean "Feature-527" {Price 326}
+                                                        Real "Feature-275"
+                                                                alternative
+                                                                        Boolean "Feature-286"
+                                                                                [0..1]
+                                                                                        Boolean "Feature-305" {Price 896}
+                                                                        Boolean "Feature-303" {Price 554}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-411" cardinality [1..5] {Price 315}
+                                                                                        Boolean "Feature-417" {Price 293}
+                                                        String "Feature-536" {Price 327}
+                                        Integer "Feature-109"
+                                        Boolean "Feature-414" cardinality [1..5]
+                                                optional
+                                                        Boolean "Feature-499"
+                        Boolean "Feature-39" {Price 512}
+                                [0..1]
+                                        Boolean "Feature-69" cardinality [1..5] {Price 416}
+                                                optional
+                                                        String "Feature-86" {Price 606}
+                                                                alternative
+                                                                        Boolean "Feature-115" cardinality [1..5]
+                                                                                or
+                                                                                        Boolean "Feature-143" {Price 837}
+                                                                                        Boolean "Feature-321" {Price 587}
+                                                                                        String "Feature-394" {Price 452}
+                                                                        Boolean "Feature-201"
+                                                                                mandatory
+                                                                                        Boolean "Feature-212"
+                                                                                        Boolean "Feature-280" {Price 550}
+                                                                        Boolean "Feature-282" {Price 661}
+                                                                                optional
+                                                                                        Integer "Feature-440"
+                                                                                        Boolean "Feature-538" {Fun 23}
+                                                                        Boolean "Feature-452" {Price 940}
+                                                                        Integer "Feature-521"
+                                        Boolean "Feature-70"
+                                                [1..3]
+                                                        Boolean "Feature-78"
+                                                                [1..2]
+                                                                        Real "Feature-126" {Price 651}
+                                                                                alternative
+                                                                                        String "Feature-423" {Fun 27}
+                                                                        Boolean "Feature-379" {Price 193}
+                                                                                optional
+                                                                                        Real "Feature-385" {Price 100, Fun 60}
+                                                        Real "Feature-207" cardinality [1..5]
+                                                                or
+                                                                        Boolean "Feature-210" {Fun -16}
+                                                                                mandatory
+                                                                                        Boolean "Feature-273" {Price 334}
+                                                                                        Real "Feature-360" {Price 60}
+                                                                        Integer "Feature-383" {Price 689}
+                                                        Real "Feature-265" {Price 856}
+                                                                alternative
+                                                                        Boolean "Feature-299" {Price 487}
+                                                                        Boolean "Feature-543" cardinality [1..5]
+                                                        String "Feature-292" {Fun 34}
+                                                                alternative
+                                                                        Boolean "Feature-325" {Price 209}
+                                                        Boolean "Feature-329" cardinality [1..5]
+                                                                alternative
+                                                                        Boolean "Feature-405"
+                                                                                alternative
+                                                                                        Boolean "Feature-425"
+                                                                        Boolean "Feature-433"
+                                                        Boolean "Feature-413"
+                                        Boolean "Feature-172"
+                                        Integer "Feature-261"
+                                                [1..2]
+                                                        Boolean "Feature-283"
+                                                                alternative
+                                                                        Boolean "Feature-398" {Price 388}
+                                                                                or
+                                                                                        Integer "Feature-520" cardinality [1..5] {Price 52}
+                                                        Boolean "Feature-346" {Price 457}
+                                        Boolean "Feature-320"
+                                                alternative
+                                                        Boolean "Feature-415"
+                                                        Boolean "Feature-435"
+                        Boolean "Feature-339" cardinality [1..5] {Price 691}
+                                or
+                                        Boolean "Feature-366" {Price 358}
+                        String "Feature-444" {Price 895}
+                        Boolean "Feature-542" {Price 637}
+
+constraints
+        "Feature-476" <=> "Feature-449" & "Feature-313" & "Feature-246" & "Feature-280" | "Feature-379" | "Feature-76" & "Feature-174" | "Feature-418" & "Feature-310" | "Feature-35" => !"Feature-369"
+        avg(Fun) > 103
+        "Feature-112" => "Feature-315" | "Feature-8" | "Feature-379" <=> "Feature-160" & "Feature-146" | "Feature-472" => "Feature-544" & "Feature-374" => "Feature-499" & "Feature-513" <=> !"Feature-197"
+        "Feature-112" => "Feature-222" & "Feature-336" | "Feature-235" => "Feature-102" => "Feature-23" <=> "Feature-342" <=> "Feature-240"
+        "Feature-77" == '-1957450421'
+        "Feature-241" | "Feature-120" & "Feature-27" => "Feature-68" => !"Feature-175"
+        "Feature-434" <=> "Feature-218" | "Feature-30" & !"Feature-494"
+        "Feature-90" <=> "Feature-529" | "Feature-145" => "Feature-388" & !"Feature-313"
+        "Feature-397" <=> "Feature-405" <=> "Feature-27" => "Feature-131" | !"Feature-333"
+        "Feature-246" => "Feature-240" | "Feature-66" <=> "Feature-481" & "Feature-208" | "Feature-456" <=> "Feature-294" | "Feature-334" | "Feature-90" & !"Feature-377"
+        "Feature-175" => "Feature-496" => "Feature-195" <=> "Feature-8" => !"Feature-375"
+        "Feature-244" => "Feature-361" <=> "Feature-321" => "Feature-154" <=> "Feature-0" <=> "Feature-364" | "Feature-386" => "Feature-525" | "Feature-488" | "Feature-349" | "Feature-180" => "Feature-52" <=> "Feature-163" | !"Feature-161"
+        "Feature-341" => "Feature-342" <=> "Feature-213" => "Feature-82" <=> "Feature-429" & "Feature-469" => "Feature-162" & "Feature-76" & "Feature-464" & "Feature-361" | "Feature-166" <=> "Feature-308" <=> "Feature-112" & "Feature-364"
+        "Feature-488" => "Feature-363" => "Feature-525" <=> "Feature-94" | "Feature-535"
+        "Feature-528" => "Feature-125" <=> "Feature-282"
+        "Feature-474" => "Feature-512" => "Feature-172" => "Feature-293" | "Feature-417" & "Feature-459" & "Feature-147" => "Feature-530" => "Feature-435" <=> "Feature-543" & "Feature-303" => "Feature-50" | "Feature-507" | !"Feature-287"
+        "Feature-529" | "Feature-294" | "Feature-228" & "Feature-378" <=> "Feature-441"
+        "Feature-147" => "Feature-433" => "Feature-210" <=> "Feature-321" & "Feature-332"
+        "Feature-309" => "Feature-497" <=> !"Feature-50"
+        "Feature-90" <=> !"Feature-456"
+        "Feature-480" == '1766388712'
+        "Feature-315" <=> "Feature-499" <=> "Feature-256" | "Feature-247" => "Feature-281" => "Feature-466" <=> "Feature-225" <=> "Feature-433" | "Feature-150" & "Feature-161" | "Feature-518" <=> "Feature-456" => "Feature-351"
+        "Feature-76" & "Feature-246" | "Feature-432" => "Feature-381" & "Feature-19"
+        "Feature-502" <=> "Feature-41"
+        "Feature-223" == '668596965'
+        sum(Fun) > 61
+        "Feature-11" | "Feature-6" => "Feature-279" | "Feature-417" & "Feature-102" & "Feature-312" & "Feature-211" => "Feature-388" <=> "Feature-467" => "Feature-359" <=> "Feature-175"
+        "Feature-225" => "Feature-378" & "Feature-181" & "Feature-215" & "Feature-173"
+        "Feature-211" | "Feature-499" | "Feature-237" <=> "Feature-208" | "Feature-314" | "Feature-27" <=> "Feature-376" <=> "Feature-32" => "Feature-72" => "Feature-321" & "Feature-317" => "Feature-73" | !"Feature-198"
+        "Feature-50" => "Feature-48" => "Feature-19" <=> "Feature-128" => "Feature-374" | "Feature-160"
+        "Feature-157" == '2021647865'
+        "Feature-282" <=> "Feature-343" <=> "Feature-502" <=> "Feature-76"
+        len("Feature-157") == 683
+        "Feature-85" | "Feature-194" & "Feature-27" | "Feature-237" <=> "Feature-380" & "Feature-21" => "Feature-51" <=> "Feature-142" => "Feature-208" | "Feature-506" <=> "Feature-341" & "Feature-484"
+        "Feature-165" => "Feature-405" <=> "Feature-449" | "Feature-331" | "Feature-315" => "Feature-201" & !"Feature-535"
+        "Feature-528" => "Feature-476" | "Feature-320" | "Feature-190" | !"Feature-50"
+        "Feature-112" => "Feature-70" <=> "Feature-449" | "Feature-441" <=> "Feature-179" <=> "Feature-131" | "Feature-94" <=> "Feature-50" => "Feature-263" & "Feature-528" | "Feature-379" & "Feature-52"
+        "Feature-296" | "Feature-181" => "Feature-4" <=> "Feature-172" <=> "Feature-222"
+        "Feature-170" <=> "Feature-397" & "Feature-334" & "Feature-226" | "Feature-27" => "Feature-43" & "Feature-463" & "Feature-191" <=> "Feature-290" => "Feature-115" <=> "Feature-509" & "Feature-388"
+        "Feature-394".Price * "Feature-512".Price != "Feature-284".Price * "Feature-210".Fun + "Feature-145".Price + "Feature-465".Price / "Feature-280".Price / "Feature-203".Price / "Feature-350".Price * "Feature-102".Price * "Feature-496".Price - "Feature-287".Price
+        "Feature-497" => "Feature-172" <=> "Feature-73" <=> "Feature-199" | "Feature-206" & "Feature-166" & "Feature-226" | "Feature-88" => "Feature-310" | "Feature-455" & "Feature-220"
+        "Feature-211" => "Feature-4" <=> "Feature-426" & "Feature-407" | "Feature-443" | "Feature-35" | "Feature-99" => "Feature-65" | "Feature-533" | "Feature-263"
+        "Feature-120" => "Feature-217" => "Feature-280" => !"Feature-249"
+        "Feature-127".Price < "Feature-144".Price + "Feature-48".Fun + "Feature-345".Price + "Feature-349".Fun / "Feature-127".Price
+        "Feature-172" | "Feature-386" | "Feature-88" => "Feature-62" <=> "Feature-528" => "Feature-237" <=> "Feature-466" <=> "Feature-467" <=> "Feature-282" & "Feature-256" | !"Feature-247"
+        "Feature-117" => "Feature-505" => "Feature-545" <=> "Feature-56" | "Feature-429" => "Feature-495" | "Feature-147" => "Feature-474" | "Feature-170" <=> "Feature-509" | "Feature-519" => "Feature-286"
+        len("Feature-54") == 139
+        "Feature-2".Price * "Feature-29".Price == "Feature-237".Price
+        "Feature-535" | "Feature-10"
+        "Feature-416" => "Feature-187" | "Feature-334" & "Feature-98" | !"Feature-453"
+        "Feature-19" <=> "Feature-138"
+        "Feature-484" <=> "Feature-504" | "Feature-486" <=> "Feature-206" => "Feature-244" <=> !"Feature-90"
+        "Feature-351" & "Feature-331" & "Feature-0" <=> "Feature-29" => "Feature-447" => "Feature-229" => "Feature-349" <=> !"Feature-161"
+        "Feature-194" | "Feature-99" & "Feature-290" & "Feature-268" <=> "Feature-162" <=> "Feature-43" | "Feature-211" & "Feature-114" <=> "Feature-490" | "Feature-264" & "Feature-336" | "Feature-172"
+        "Feature-202".Price + "Feature-44".Price + "Feature-263".Price * "Feature-97".Fun == "Feature-349".Fun / "Feature-303".Price / "Feature-276".Price - "Feature-110".Price - "Feature-451".Price
+        "Feature-111" | "Feature-533" => "Feature-140" <=> "Feature-120" <=> "Feature-455" | !"Feature-4"
+        "Feature-0" => "Feature-314" <=> "Feature-539" <=> "Feature-361" | "Feature-327" <=> "Feature-76" <=> "Feature-525" => "Feature-294" | "Feature-353" | !"Feature-160"
+        "Feature-280" | "Feature-240" <=> "Feature-513" | "Feature-473" | "Feature-329" & "Feature-43" | "Feature-429" & "Feature-294" | "Feature-168" <=> "Feature-476" <=> "Feature-293" <=> "Feature-386"
+        "Feature-128" | "Feature-430" <=> "Feature-414" & "Feature-197" & "Feature-257" & "Feature-214" => "Feature-447"
+        "Feature-97" | "Feature-413" => "Feature-516" => "Feature-31" <=> "Feature-359" <=> "Feature-127" <=> "Feature-452" <=> "Feature-396" | "Feature-82" <=> "Feature-166" <=> "Feature-418" | !"Feature-407"
+        "Feature-85" | "Feature-513" <=> "Feature-111" | "Feature-208" => "Feature-359" | "Feature-247" | "Feature-457" | "Feature-331"
+        "Feature-112" <=> "Feature-321" <=> "Feature-541" <=> "Feature-12" <=> "Feature-247" => "Feature-52" <=> "Feature-469" => "Feature-376" | "Feature-309" | !"Feature-82"
+        "Feature-379" | "Feature-136" => "Feature-52" <=> "Feature-62" => "Feature-133" <=> "Feature-10" | "Feature-19" <=> "Feature-490"
+        len("Feature-251") == 583
+        sum(Fun) > -24
+        "Feature-181" => "Feature-241" & "Feature-281" => "Feature-320"
+        "Feature-66" => "Feature-255" & "Feature-375" => "Feature-268" <=> "Feature-333" <=> "Feature-329" & "Feature-291" | "Feature-102" | "Feature-241" <=> "Feature-543" <=> "Feature-234" => !"Feature-98"
+        "Feature-469" <=> "Feature-473" <=> "Feature-148" | "Feature-177" <=> "Feature-210" => "Feature-516" <=> "Feature-405" | !"Feature-88"
+        "Feature-432" <=> "Feature-411" & "Feature-30" & "Feature-99" <=> "Feature-359" | "Feature-530" & "Feature-11" <=> "Feature-498" => "Feature-104" => !"Feature-27"
+        "Feature-119".Fun == "Feature-293".Fun
+        len("Feature-536") == 509
+        "Feature-259" => "Feature-35" & "Feature-198" <=> "Feature-127"
+        "Feature-174" => "Feature-269" | "Feature-51" | "Feature-0" & !"Feature-376"
+        "Feature-499" <=> "Feature-191" & !"Feature-263"
+        "Feature-51" => "Feature-41" => "Feature-238" <=> "Feature-291" => "Feature-237" & "Feature-0" | "Feature-31" <=> "Feature-128" <=> "Feature-191" <=> "Feature-280" <=> "Feature-108" & "Feature-352"

--- a/test_resources/parsing/generated/fm4.uvl
+++ b/test_resources/parsing/generated/fm4.uvl
@@ -1,0 +1,818 @@
+features
+        String "Feature-0"
+                alternative
+                        Boolean "Feature-1" {Price 810}
+                                optional
+                                        Boolean "Feature-2" {Price 797}
+                                                mandatory
+                                                        Real "Feature-3" cardinality [1..5]
+                                                                mandatory
+                                                                        Boolean "Feature-9"
+                                                                                alternative
+                                                                                        Boolean "Feature-11"
+                                                                                        Boolean "Feature-39" {Price 922}
+                                                                                        Boolean "Feature-74"
+                                                                                        Boolean "Feature-79"
+                                                                                        Boolean "Feature-88"
+                                                                                        Boolean "Feature-326" {Price 797}
+                                                                                        Boolean "Feature-350"
+                                                                                        Boolean "Feature-388"
+                                                                        Boolean "Feature-31"
+                                                                                alternative
+                                                                                        Boolean "Feature-92" cardinality [1..5]
+                                                                        Boolean "Feature-190" cardinality [1..5] {Price 816}
+                                                                                [1..2]
+                                                                                        Real "Feature-477"
+                                                                                        Boolean "Feature-479" {Price 921}
+                                                                        Boolean "Feature-200" {Price 354}
+                                                                                mandatory
+                                                                                        Boolean "Feature-264" {Price 662}
+                                                                                        Boolean "Feature-349" {Price 223}
+                                                                                        Integer "Feature-433" {Price 880}
+                                                                                        Integer "Feature-442"
+                                                                                        Boolean "Feature-468"
+                                                                                        Boolean "Feature-490" {Price 613}
+                                                                                        Boolean "Feature-542" {Fun 75}
+                                                                        Boolean "Feature-325"
+                                                        Boolean "Feature-4" {Price 946}
+                                                                or
+                                                                        Boolean "Feature-22" {Price 948}
+                                                                                mandatory
+                                                                                        Integer "Feature-29" cardinality [1..5]
+                                                                                        Boolean "Feature-58" {Price 657}
+                                                                                        Integer "Feature-82"
+                                                                                        Real "Feature-153" cardinality [1..5] {Price 529}
+                                                                                        Boolean "Feature-382" {Price 334}
+                                                                                        Boolean "Feature-423" cardinality [1..5]
+                                                                                        Boolean "Feature-484"
+                                                                        Real "Feature-61" {Price 834}
+                                                                                [3..3]
+                                                                                        Boolean "Feature-141" cardinality [1..5]
+                                                                                        Boolean "Feature-366" {Price 139}
+                                                                                        Boolean "Feature-376" {Price 896}
+                                                                        Boolean "Feature-113"
+                                                                                alternative
+                                                                                        Boolean "Feature-197"
+                                                                                        String "Feature-257" cardinality [1..5]
+                                                        Boolean "Feature-15" cardinality [1..5] {Price 540}
+                                                                [1..1]
+                                                                        Boolean "Feature-44" {Price 817, Fun -17}
+                                                                                alternative
+                                                                                        Boolean "Feature-59"
+                                                                                        Boolean "Feature-228" {Price 777}
+                                                                                        Boolean "Feature-516" cardinality [1..5] {Fun -51}
+                                                                        Boolean "Feature-91" cardinality [1..5]
+                                                                                [1..1]
+                                                                                        Boolean "Feature-97" {Price 48}
+                                                                                        Integer "Feature-107" {Fun 33}
+                                                                                        Boolean "Feature-209" {Price 215}
+                                                                                        Boolean "Feature-292"
+                                                                                        Boolean "Feature-379" cardinality [1..5] {Price 837}
+                                                                        Boolean "Feature-428" {Price 746}
+                                                                                mandatory
+                                                                                        Integer "Feature-462" {Price 592}
+                                                        Boolean "Feature-18" {Price 926}
+                                                                alternative
+                                                                        Boolean "Feature-30" cardinality [1..5] {Price 872}
+                                                                        Boolean "Feature-41"
+                                                                                mandatory
+                                                                                        Boolean "Feature-64" cardinality [1..5] {Price 787}
+                                                                                        Boolean "Feature-66" cardinality [1..5] {Price 696}
+                                                                                        Boolean "Feature-203" {Price 536}
+                                                                                        Integer "Feature-249"
+                                                                                        Boolean "Feature-252" cardinality [1..5]
+                                                                                        Integer "Feature-368" {Price 693}
+                                                                                        Boolean "Feature-418"
+                                                                        Boolean "Feature-60" {Price 662, Fun 85}
+                                                                                alternative
+                                                                                        Boolean "Feature-167" cardinality [1..5] {Price 441}
+                                                                                        Real "Feature-243" {Price 655, Fun -82}
+                                                                                        Integer "Feature-402" {Price 946}
+                                                                        Boolean "Feature-75"
+                                                                                optional
+                                                                                        Boolean "Feature-101"
+                                                                                        Boolean "Feature-154" {Price 68}
+                                                                                        Integer "Feature-430"
+                                                                        Boolean "Feature-135" {Price 382}
+                                                                                mandatory
+                                                                                        Integer "Feature-175"
+                                                                        Boolean "Feature-213" {Price 197}
+                                                                                alternative
+                                                                                        Boolean "Feature-472" cardinality [1..5] {Price 688}
+                                                                        Integer "Feature-229"
+                                                                        Integer "Feature-511" {Price 467}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-547" cardinality [1..5]
+                                                        Boolean "Feature-40" {Price 784}
+                                                                or
+                                                                        Boolean "Feature-89" {Price 895}
+                                                                                or
+                                                                                        Boolean "Feature-274" cardinality [1..5]
+                                                                                        Integer "Feature-362"
+                                                                        Boolean "Feature-143" {Price 349}
+                                                                                optional
+                                                                                        Integer "Feature-155" {Price 663}
+                                                                                        Integer "Feature-361" {Price 792}
+                                                                        Integer "Feature-160" {Price 735}
+                                                                                mandatory
+                                                                                        Boolean "Feature-344" cardinality [1..5] {Price 306}
+                                                                                        Boolean "Feature-410" {Price 329}
+                                                        Boolean "Feature-57" cardinality [1..5] {Price 741}
+                                                                or
+                                                                        Boolean "Feature-70" {Price 831}
+                                                                                [0..2]
+                                                                                        Boolean "Feature-117"
+                                                                                        Boolean "Feature-277" {Price 322}
+                                                                        Boolean "Feature-244"
+                                                                                mandatory
+                                                                                        Boolean "Feature-267" {Price 507}
+                                                                                        Boolean "Feature-298" {Price 291}
+                                                                                        Boolean "Feature-313" {Price 365}
+                                                                        Boolean "Feature-487" cardinality [1..5]
+                                                        Boolean "Feature-439"
+                                                                alternative
+                                                                        Boolean "Feature-496"
+                                                                                optional
+                                                                                        Integer "Feature-543"
+                                        Integer "Feature-6"
+                                                mandatory
+                                                        Boolean "Feature-16"
+                                                                mandatory
+                                                                        Boolean "Feature-139" {Price 626}
+                                                                                alternative
+                                                                                        Boolean "Feature-180"
+                                                                        Integer "Feature-151" cardinality [1..5]
+                                                                                or
+                                                                                        Boolean "Feature-400"
+                                                                                        Boolean "Feature-411"
+                                                                        Boolean "Feature-242"
+                                                                        Integer "Feature-467"
+                                                                        Boolean "Feature-523" {Price 962}
+                                                                                [0..1]
+                                                                                        Integer "Feature-539"
+                                                        Boolean "Feature-32" {Fun 1}
+                                                                [0..5]
+                                                                        Boolean "Feature-55" cardinality [1..5] {Price 489}
+                                                                                alternative
+                                                                                        Boolean "Feature-87" {Fun 28}
+                                                                                        Boolean "Feature-115" cardinality [1..5] {Price 833}
+                                                                                        String "Feature-145" {Price 685}
+                                                                                        Integer "Feature-394"
+                                                                        Boolean "Feature-62" cardinality [1..5]
+                                                                                [1..1]
+                                                                                        Boolean "Feature-71" cardinality [1..5] {Price 608}
+                                                                                        Boolean "Feature-84" {Price 282}
+                                                                                        Real "Feature-174" {Price 710}
+                                                                                        Boolean "Feature-273" cardinality [1..5] {Price 432}
+                                                                        Boolean "Feature-96" {Price 245}
+                                                                                alternative
+                                                                                        Real "Feature-207"
+                                                                                        Real "Feature-491" {Price 740}
+                                                                        Boolean "Feature-102" cardinality [1..5]
+                                                                                mandatory
+                                                                                        Boolean "Feature-110" {Price 764, Fun 40}
+                                                                        Integer "Feature-147"
+                                                                                [0..1]
+                                                                                        Boolean "Feature-255" {Fun 7}
+                                                                                        Boolean "Feature-258" cardinality [1..5] {Price 410}
+                                                                        Integer "Feature-238" {Price 919}
+                                                                                [1..1]
+                                                                                        Boolean "Feature-241"
+                                                                        Boolean "Feature-248"
+                                                                        Boolean "Feature-431" cardinality [1..5]
+                                                                                alternative
+                                                                                        Boolean "Feature-441" {Price 521}
+                                                        Integer "Feature-46"
+                                                                mandatory
+                                                                        Integer "Feature-94" cardinality [1..5] {Price 835}
+                                                                                mandatory
+                                                                                        Boolean "Feature-138"
+                                                                        Real "Feature-108" {Price 625}
+                                                                                or
+                                                                                        String "Feature-136" cardinality [1..5]
+                                                                                        Boolean "Feature-158" cardinality [1..5]
+                                                                                        String "Feature-184"
+                                                                                        Integer "Feature-253" cardinality [1..5]
+                                                                                        Boolean "Feature-351"
+                                                                                        Boolean "Feature-401" {Price 989}
+                                                                                        Integer "Feature-414" cardinality [1..5]
+                                                                                        Boolean "Feature-494" {Price 704}
+                                                                        String "Feature-114" {Price 31}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-150" cardinality [1..5]
+                                                                                        Integer "Feature-179" cardinality [1..5]
+                                                                                        Boolean "Feature-520" {Price 849}
+                                                                        Boolean "Feature-119"
+                                                                                mandatory
+                                                                                        Boolean "Feature-474"
+                                                                        Integer "Feature-275"
+                                                                                alternative
+                                                                                        Boolean "Feature-297" {Price 771}
+                                                                                        String "Feature-363" cardinality [1..5]
+                                                                                        Boolean "Feature-407" cardinality [1..5]
+                                                                                        Boolean "Feature-475"
+                                                        Boolean "Feature-112" {Fun 73}
+                                                                [0..3]
+                                                                        Boolean "Feature-123"
+                                                                                alternative
+                                                                                        Boolean "Feature-171" cardinality [1..5]
+                                                                                        Boolean "Feature-193"
+                                                                                        Boolean "Feature-311" {Price 325}
+                                                                                        Boolean "Feature-316" cardinality [1..5]
+                                                                                        Integer "Feature-345"
+                                                                                        Boolean "Feature-505" cardinality [1..5] {Price 697}
+                                                                        Integer "Feature-161" {Price 130}
+                                                                                mandatory
+                                                                                        Boolean "Feature-395"
+                                                                        Boolean "Feature-341"
+                                                                                [0..1]
+                                                                                        Boolean "Feature-448" cardinality [1..5]
+                                                        Integer "Feature-170" {Price 215}
+                                                                or
+                                                                        Boolean "Feature-212" {Price 443}
+                                                                                [2..2]
+                                                                                        Boolean "Feature-222" {Price 967}
+                                                                                        Boolean "Feature-284" {Price 363}
+                                                                                        Boolean "Feature-413" {Price 576}
+                                                                        String "Feature-234" {Price 526}
+                                                                                alternative
+                                                                                        String "Feature-466"
+                                                        String "Feature-188" {Price 806, Fun -73}
+                                                                mandatory
+                                                                        Integer "Feature-246"
+                                                                                optional
+                                                                                        Integer "Feature-259"
+                                                                                        Real "Feature-323"
+                                                                        Real "Feature-289" {Price 310}
+                                                                                optional
+                                                                                        Boolean "Feature-408"
+                                                                                        Boolean "Feature-437" {Price 696}
+                                                        Boolean "Feature-386" cardinality [1..5]
+                                                        Boolean "Feature-503"
+                                        Integer "Feature-28" {Price 473}
+                                                alternative
+                                                        Boolean "Feature-33" cardinality [1..5] {Price 617}
+                                                                [1..3]
+                                                                        Integer "Feature-50"
+                                                                                mandatory
+                                                                                        Boolean "Feature-56" {Price 88}
+                                                                                        Boolean "Feature-137"
+                                                                                        Boolean "Feature-406"
+                                                                                        Boolean "Feature-458"
+                                                                        Boolean "Feature-73" {Price 650}
+                                                                                alternative
+                                                                                        Boolean "Feature-109" {Price 202}
+                                                                                        Real "Feature-226" {Price 348}
+                                                                                        Real "Feature-291" {Price 729}
+                                                                                        Boolean "Feature-495"
+                                                                        Boolean "Feature-176" cardinality [1..5]
+                                                                                mandatory
+                                                                                        Integer "Feature-338" cardinality [1..5]
+                                                                        Boolean "Feature-240" cardinality [1..5]
+                                                                                or
+                                                                                        Boolean "Feature-256" {Price 599}
+                                                                                        Boolean "Feature-419" cardinality [1..5] {Price 974, Fun 64}
+                                                                                        Integer "Feature-432"
+                                                                        Boolean "Feature-454"
+                                                                        Integer "Feature-459"
+                                                        Boolean "Feature-83" {Price 332}
+                                                                mandatory
+                                                                        Boolean "Feature-116" {Price 757}
+                                                                                alternative
+                                                                                        Boolean "Feature-140" cardinality [1..5] {Fun 98}
+                                                                                        Boolean "Feature-232" cardinality [1..5] {Price 533}
+                                                                                        Boolean "Feature-282" {Price 256}
+                                                                                        Boolean "Feature-385" {Price 876}
+                                                                                        String "Feature-389" {Fun -7}
+                                                                        Integer "Feature-288" cardinality [1..5] {Price 733}
+                                                                                mandatory
+                                                                                        Integer "Feature-381"
+                                                                                        Boolean "Feature-451"
+                                                                        Boolean "Feature-332" cardinality [1..5]
+                                                                        Integer "Feature-455"
+                                                                        Boolean "Feature-501"
+                                                        Boolean "Feature-99" {Price 925}
+                                                                or
+                                                                        Boolean "Feature-100" {Price 73}
+                                                                                alternative
+                                                                                        Boolean "Feature-121"
+                                                                                        Boolean "Feature-272" cardinality [1..5] {Price 818}
+                                                                                        Boolean "Feature-446" {Price 225}
+                                                                        Boolean "Feature-124"
+                                                                                optional
+                                                                                        Boolean "Feature-276" cardinality [1..5]
+                                                                                        Boolean "Feature-540" {Price 235}
+                                                                        Boolean "Feature-165"
+                                                                                or
+                                                                                        Real "Feature-185" {Price 857}
+                                                                                        Integer "Feature-225"
+                                                                                        Boolean "Feature-295"
+                                                                        Boolean "Feature-339"
+                                                                        String "Feature-405" {Price 60}
+                                                        Boolean "Feature-120"
+                                                                alternative
+                                                                        Boolean "Feature-210"
+                                                                                or
+                                                                                        Real "Feature-312"
+                                                                                        Integer "Feature-531" cardinality [1..5]
+                                                                        Boolean "Feature-488" {Price 198, Fun -23}
+                                                                                or
+                                                                                        Boolean "Feature-514" {Price 484, Fun -34}
+                                                                                        Integer "Feature-529" cardinality [1..5]
+                                                                                        Boolean "Feature-533"
+                                                        Integer "Feature-187" cardinality [1..5] {Price 655}
+                                                                mandatory
+                                                                        String "Feature-198" {Price 766}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-279" {Price 175}
+                                                                        Boolean "Feature-208" {Price 451}
+                                                                                mandatory
+                                                                                        Integer "Feature-347" {Price 109}
+                                                                                        Boolean "Feature-398" {Price 265}
+                                                                        Boolean "Feature-281"
+                                                                                alternative
+                                                                                        Boolean "Feature-470"
+                                                                                        Boolean "Feature-544" {Price 433}
+                                                        Boolean "Feature-515" cardinality [1..5] {Price 650}
+                                        Boolean "Feature-35" {Fun 32}
+                                                alternative
+                                                        Boolean "Feature-36"
+                                                                alternative
+                                                                        Boolean "Feature-42"
+                                                                                mandatory
+                                                                                        String "Feature-54" {Price 430, Fun -68}
+                                                                                        Boolean "Feature-68" {Price 249}
+                                                                                        Boolean "Feature-126" {Price 341}
+                                                                                        Integer "Feature-231"
+                                                                                        String "Feature-358" cardinality [1..5]
+                                                                                        Real "Feature-412" {Price 826}
+                                                                        Boolean "Feature-49" {Price 160}
+                                                                        Boolean "Feature-76"
+                                                                                mandatory
+                                                                                        Boolean "Feature-201" cardinality [1..5]
+                                                                                        Integer "Feature-403" cardinality [1..5] {Price 585}
+                                                                        Boolean "Feature-262"
+                                                                        Boolean "Feature-417" cardinality [1..5] {Price 68}
+                                                                                or
+                                                                                        Boolean "Feature-436" cardinality [1..5]
+                                                                        Boolean "Feature-434" cardinality [1..5] {Price 659, Fun -85}
+                                                                                or
+                                                                                        Boolean "Feature-534"
+                                                        Boolean "Feature-129" {Fun -7}
+                                                                alternative
+                                                                        Integer "Feature-223" {Price 703, Fun -13}
+                                                                        Boolean "Feature-293"
+                                                                                alternative
+                                                                                        Boolean "Feature-372"
+                                                                                        Integer "Feature-429" cardinality [1..5] {Price 419}
+                                                        String "Feature-164" {Price 652}
+                                                        Boolean "Feature-191" cardinality [1..5]
+                                                                or
+                                                                        Integer "Feature-357"
+                                                                                or
+                                                                                        Integer "Feature-535" {Price 706}
+                                                                        Boolean "Feature-373" cardinality [1..5]
+                                                                        Boolean "Feature-427"
+                                                                        Boolean "Feature-443"
+                                                                                or
+                                                                                        Boolean "Feature-524"
+                                                        Boolean "Feature-217" {Price 833}
+                                                                alternative
+                                                                        Boolean "Feature-260"
+                                                                                alternative
+                                                                                        String "Feature-440"
+                                                                        Boolean "Feature-299" cardinality [1..5] {Price 490}
+                                                                                [1..1]
+                                                                                        Boolean "Feature-308" {Price 547}
+                                                                                        Integer "Feature-377" cardinality [1..5]
+                                        Boolean "Feature-69"
+                                                optional
+                                                        Boolean "Feature-81"
+                                                                optional
+                                                                        Boolean "Feature-98"
+                                                                                mandatory
+                                                                                        Boolean "Feature-186" {Fun 63}
+                                                                                        Boolean "Feature-321" cardinality [1..5] {Price 854}
+                                                                                        Real "Feature-352" {Price 322}
+                                                                        Boolean "Feature-214" {Price 946}
+                                                                                [1..2]
+                                                                                        Boolean "Feature-393"
+                                                                                        Boolean "Feature-435"
+                                                                                        Boolean "Feature-478"
+                                                                        Boolean "Feature-239"
+                                                                                alternative
+                                                                                        Boolean "Feature-549" {Price 120}
+                                                                        Boolean "Feature-251" {Price 779}
+                                                                                alternative
+                                                                                        Boolean "Feature-342" {Price 578}
+                                                                                        Boolean "Feature-364"
+                                                                                        Boolean "Feature-512"
+                                                        String "Feature-152"
+                                                                [0..2]
+                                                                        Integer "Feature-336" cardinality [1..5] {Fun 91}
+                                                                                alternative
+                                                                                        Boolean "Feature-447"
+                                                                        Boolean "Feature-493"
+                                                        Boolean "Feature-486"
+                                        Boolean "Feature-156"
+                                        Boolean "Feature-237"
+                                                mandatory
+                                                        Boolean "Feature-261" {Price 232}
+                                                                [0..1]
+                                                                        String "Feature-300"
+                                                                                [0..1]
+                                                                                        Integer "Feature-530" cardinality [1..5] {Price 517}
+                                                        Boolean "Feature-304"
+                                                        Integer "Feature-404"
+                                                                alternative
+                                                                        Boolean "Feature-526"
+                        Boolean "Feature-5" {Price 158}
+                                alternative
+                                        Boolean "Feature-8" {Price 695}
+                                                [2..4]
+                                                        Integer "Feature-10" cardinality [1..5] {Price 372}
+                                                                or
+                                                                        Integer "Feature-19" cardinality [1..5]
+                                                                                alternative
+                                                                                        Integer "Feature-528" {Price 870}
+                                                                        Boolean "Feature-24" cardinality [1..5] {Price 855}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-85" {Fun -64}
+                                                                        Boolean "Feature-27" {Price 973}
+                                                                                mandatory
+                                                                                        Boolean "Feature-38" {Price 18}
+                                                                                        String "Feature-67" cardinality [1..5] {Price 890, Fun 80}
+                                                                        Integer "Feature-48"
+                                                                                [2..3]
+                                                                                        Boolean "Feature-106" {Price 312}
+                                                                                        Integer "Feature-162" {Price 300}
+                                                                                        Boolean "Feature-331" {Price 806}
+                                                                        Boolean "Feature-221" {Price 868}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-335"
+                                                                        Boolean "Feature-230" {Price 652}
+                                                                                mandatory
+                                                                                        Boolean "Feature-294" {Price 811}
+                                                                        Integer "Feature-522" cardinality [1..5] {Price 462}
+                                                        String "Feature-14" {Price 690}
+                                                                or
+                                                                        Boolean "Feature-20" cardinality [1..5] {Price 116}
+                                                                                [0..1]
+                                                                                        Boolean "Feature-21" {Price 783}
+                                                                                        Integer "Feature-45" {Price 374}
+                                                                                        Integer "Feature-104" {Price 432}
+                                                                                        Real "Feature-157" {Price 992}
+                                                                        Boolean "Feature-25" {Price 676}
+                                                                                [1..3]
+                                                                                        Boolean "Feature-90" {Price 629}
+                                                                                        Boolean "Feature-95" {Price 91}
+                                                                                        Boolean "Feature-142" {Price 757}
+                                                                                        Boolean "Feature-236" cardinality [1..5]
+                                                                        Boolean "Feature-34" {Price 337, Fun -63}
+                                                                                [1..1]
+                                                                                        Boolean "Feature-37"
+                                                                                        Boolean "Feature-47" {Price 856}
+                                                                                        Boolean "Feature-51"
+                                                                                        Boolean "Feature-80"
+                                                                                        Boolean "Feature-149"
+                                                                                        Boolean "Feature-420" {Fun 61}
+                                                                        Boolean "Feature-65" {Price 163}
+                                                                                [1..1]
+                                                                                        Boolean "Feature-307" cardinality [1..5] {Price 480}
+                                                                                        Boolean "Feature-426"
+                                                                        Boolean "Feature-105"
+                                                                                mandatory
+                                                                                        Boolean "Feature-118"
+                                                                                        Integer "Feature-301" {Price 868}
+                                                                        Boolean "Feature-480"
+                                                        Boolean "Feature-17" {Price 299}
+                                                                [0..2]
+                                                                        Boolean "Feature-111" cardinality [1..5]
+                                                                                mandatory
+                                                                                        Boolean "Feature-128" {Price 362}
+                                                                                        Boolean "Feature-146" {Price 983, Fun 69}
+                                                                                        Boolean "Feature-360" {Fun 32}
+                                                                                        Boolean "Feature-438"
+                                                                                        Boolean "Feature-445" cardinality [1..5] {Price 232}
+                                                                                        Boolean "Feature-456"
+                                                                                        Boolean "Feature-464" {Price 782}
+                                                                        Boolean "Feature-320" {Price 484}
+                                                        String "Feature-78" {Price 328}
+                                                                or
+                                                                        String "Feature-172" cardinality [1..5]
+                                                                                alternative
+                                                                                        Integer "Feature-178" {Price 581}
+                                                                                        Boolean "Feature-263" {Fun -65}
+                                                                                        String "Feature-280"
+                                                                                        Integer "Feature-318" cardinality [1..5] {Price 200}
+                                                                                        Boolean "Feature-527" cardinality [1..5]
+                                                                        Integer "Feature-173" {Price 637}
+                                                                                or
+                                                                                        Boolean "Feature-202" cardinality [1..5] {Price 544}
+                                                                                        Integer "Feature-290" {Price 290}
+                                                                                        Integer "Feature-322" cardinality [1..5] {Price 462, Fun 60}
+                                                                                        Real "Feature-375"
+                                                                                        Integer "Feature-481"
+                                                        String "Feature-103" cardinality [1..5] {Price 750}
+                                                                or
+                                                                        Boolean "Feature-144" cardinality [1..5] {Price 206}
+                                                                                or
+                                                                                        Integer "Feature-250"
+                                                                                        Boolean "Feature-356" {Price 827}
+                                                                                        Boolean "Feature-367" cardinality [1..5] {Price 849, Fun 85}
+                                                                        String "Feature-287" {Price 47}
+                                                                                [1..1]
+                                                                                        Boolean "Feature-324" cardinality [1..5]
+                                                                        String "Feature-327" {Price 307}
+                                                                                optional
+                                                                                        String "Feature-399"
+                                                                        Boolean "Feature-355" {Fun 78}
+                                                                        Boolean "Feature-548" {Price 851}
+                                                        Boolean "Feature-127" cardinality [1..5]
+                                                                optional
+                                                                        Boolean "Feature-266"
+                                                                                or
+                                                                                        Integer "Feature-409" {Price 537}
+                                                                        Boolean "Feature-397" {Price 542}
+                                                        Integer "Feature-315"
+                                                        Boolean "Feature-340" {Price 82}
+                                                        Real "Feature-396" cardinality [1..5]
+                                                                optional
+                                                                        Boolean "Feature-422"
+                                                                                or
+                                                                                        Boolean "Feature-538" cardinality [1..5] {Price 598}
+                                                                        Boolean "Feature-449" cardinality [1..5] {Fun -39}
+                                        Integer "Feature-52"
+                                                optional
+                                                        Integer "Feature-72" {Price 69, Fun 65}
+                                                                optional
+                                                                        Integer "Feature-348" {Price 910}
+                                                        Boolean "Feature-215" {Fun 57}
+                                                                mandatory
+                                                                        Boolean "Feature-309"
+                                        Boolean "Feature-93" {Fun 76}
+                                                or
+                                                        Boolean "Feature-303"
+                                                                [1..2]
+                                                                        Boolean "Feature-453"
+                                                                                [0..1]
+                                                                                        Integer "Feature-498" cardinality [1..5]
+                                                                        Boolean "Feature-507"
+                                                                                alternative
+                                                                                        Boolean "Feature-510"
+                                                        Integer "Feature-306" cardinality [1..5] {Price 32}
+                                                        Boolean "Feature-500"
+                                                        Integer "Feature-513" cardinality [1..5] {Price 496}
+                                        Boolean "Feature-125"
+                                                [2..2]
+                                                        Real "Feature-169" {Price 753}
+                                                                [0..1]
+                                                                        Boolean "Feature-278" cardinality [1..5] {Fun -23}
+                                                        String "Feature-181"
+                                                                mandatory
+                                                                        Boolean "Feature-305"
+                                                                        Boolean "Feature-497"
+                                                                                or
+                                                                                        Integer "Feature-519" cardinality [1..5] {Price 45}
+                                                                        Boolean "Feature-518" {Price 397}
+                                                        Integer "Feature-182"
+                                                                mandatory
+                                                                        Boolean "Feature-194" {Fun -13}
+                                                                                [1..1]
+                                                                                        Integer "Feature-365" {Price 970}
+                                                                        Boolean "Feature-391" cardinality [1..5] {Price 873, Fun 75}
+                                                        Boolean "Feature-189" {Price 404}
+                                                                or
+                                                                        Boolean "Feature-271"
+                                                                        Boolean "Feature-471"
+                                        Boolean "Feature-148"
+                                                optional
+                                                        Boolean "Feature-159" {Price 40}
+                                                                optional
+                                                                        Boolean "Feature-204" cardinality [1..5] {Price 16}
+                                                                                or
+                                                                                        Boolean "Feature-265"
+                                                                        String "Feature-370" {Price 479, Fun -31}
+                                                                                mandatory
+                                                                                        Integer "Feature-424"
+                                                                        Integer "Feature-444" {Price 36}
+                                                                        Integer "Feature-545" cardinality [1..5] {Price 581}
+                                                        Boolean "Feature-195"
+                                                                mandatory
+                                                                        Boolean "Feature-283" cardinality [1..5]
+                                                                        Boolean "Feature-296" {Price 675}
+                                                                                mandatory
+                                                                                        Boolean "Feature-310"
+                                                                        Boolean "Feature-330" {Price 300}
+                                                                        Integer "Feature-536" {Price 584}
+                                                        Integer "Feature-235"
+                                                                or
+                                                                        Boolean "Feature-354"
+                                        Integer "Feature-183" {Price 797, Fun 94}
+                                        Boolean "Feature-461"
+                        Boolean "Feature-7"
+                                [0..1]
+                                        Boolean "Feature-12" {Price 662}
+                                                alternative
+                                                        Boolean "Feature-26" {Price 997}
+                                                                or
+                                                                        Boolean "Feature-450"
+                                                                                alternative
+                                                                                        Boolean "Feature-483" {Price 173}
+                                                        Boolean "Feature-132" {Price 84}
+                                                        Boolean "Feature-227"
+                                                                alternative
+                                                                        Boolean "Feature-328" {Price 83, Fun 1}
+                                                        Boolean "Feature-329" {Price 358}
+                                                                [1..1]
+                                                                        Boolean "Feature-499" {Price 989}
+                                                        Real "Feature-369" {Price 452}
+                                                                or
+                                                                        Boolean "Feature-508"
+                                                        Integer "Feature-421"
+                                        Boolean "Feature-13" {Price 725}
+                                                mandatory
+                                                        Integer "Feature-23"
+                                                                mandatory
+                                                                        Boolean "Feature-53" {Fun 56}
+                                                                        Boolean "Feature-166"
+                                                                                [2..2]
+                                                                                        Real "Feature-269" cardinality [1..5] {Fun 20}
+                                                                                        Boolean "Feature-314" {Price 249}
+                                                                                        Integer "Feature-517"
+                                                                        Boolean "Feature-205" {Price 817}
+                                                                                mandatory
+                                                                                        Boolean "Feature-224" cardinality [1..5]
+                                                                                        Integer "Feature-374" {Price 295}
+                                                                        Boolean "Feature-270" {Fun 5}
+                                                                                mandatory
+                                                                                        Boolean "Feature-506" {Price 595}
+                                                                                        Integer "Feature-521" {Fun 28}
+                                                                        Boolean "Feature-346"
+                                                                                mandatory
+                                                                                        Integer "Feature-452"
+                                                                        Boolean "Feature-416" {Price 407}
+                                                                                optional
+                                                                                        Boolean "Feature-463" {Price 472}
+                                                                                        Integer "Feature-476"
+                                                                                        Boolean "Feature-537"
+                                                        Real "Feature-43"
+                                                                or
+                                                                        Boolean "Feature-177"
+                                                                                or
+                                                                                        Integer "Feature-302"
+                                                                                        Boolean "Feature-371" {Price 261}
+                                                                        Boolean "Feature-192" {Price 487}
+                                                                                or
+                                                                                        Boolean "Feature-219"
+                                                                                        Real "Feature-268"
+                                                                        Boolean "Feature-199" {Price 752}
+                                                                                alternative
+                                                                                        String "Feature-319" cardinality [1..5]
+                                                                                        Boolean "Feature-482" {Price 263}
+                                                                        Boolean "Feature-233" {Price 706}
+                                                                                mandatory
+                                                                                        Boolean "Feature-378" {Price 279}
+                                                                        Boolean "Feature-383"
+                                                                                [1..1]
+                                                                                        Boolean "Feature-469"
+                                                        Integer "Feature-63"
+                                                                optional
+                                                                        Boolean "Feature-77" {Price 244, Fun 37}
+                                                                                alternative
+                                                                                        Boolean "Feature-86"
+                                                                                        Boolean "Feature-131" cardinality [1..5] {Price 844}
+                                                                                        Boolean "Feature-211"
+                                                                                        Boolean "Feature-216" cardinality [1..5] {Price 322}
+                                                                                        Boolean "Feature-220" {Fun -55}
+                                                                        String "Feature-122" {Price 789, Fun 67}
+                                                                                alternative
+                                                                                        Boolean "Feature-384" {Price 58}
+                                                                                        Integer "Feature-465"
+                                                                                        Boolean "Feature-473" {Price 518}
+                                                                        Boolean "Feature-163" cardinality [1..5]
+                                                                                alternative
+                                                                                        Boolean "Feature-390"
+                                                        Integer "Feature-130"
+                                                                or
+                                                                        Boolean "Feature-134"
+                                                                                [2..2]
+                                                                                        Boolean "Feature-247" {Fun 94}
+                                                                                        Boolean "Feature-425" {Price 207}
+                                                                        Boolean "Feature-168" {Price 682}
+                                                                                [0..4]
+                                                                                        String "Feature-206"
+                                                                                        Boolean "Feature-245" cardinality [1..5]
+                                                                                        Boolean "Feature-343" {Price 803}
+                                                                                        Real "Feature-380" {Price 280}
+                                                                        Boolean "Feature-196"
+                                                                                or
+                                                                                        Boolean "Feature-353" {Price 385, Fun -72}
+                                                                                        Boolean "Feature-392"
+                                                                                        Boolean "Feature-457" {Price 914}
+                                                                                        Integer "Feature-504" {Price 380}
+                                                                        Boolean "Feature-317" {Price 613}
+                                                                                alternative
+                                                                                        Boolean "Feature-485" cardinality [1..5] {Price 875, Fun 4}
+                                                                        Boolean "Feature-334" {Price 192}
+                                                                        Boolean "Feature-525" {Price 661}
+                                                                        Boolean "Feature-546" {Price 396}
+                                                        Boolean "Feature-285"
+                                                                mandatory
+                                                                        Boolean "Feature-415"
+                                                                                [0..1]
+                                                                                        Boolean "Feature-492"
+                                                        Boolean "Feature-387" cardinality [1..5]
+                                                        Boolean "Feature-502" cardinality [1..5] {Price 709}
+                                                        Boolean "Feature-509" {Price 278}
+                                        Integer "Feature-133" {Price 677}
+                                                alternative
+                                                        Boolean "Feature-218"
+                                                        Boolean "Feature-254" {Price 81}
+                                                        Boolean "Feature-541" {Price 432}
+                                        Boolean "Feature-489"
+                        Boolean "Feature-286"
+                                [1..1]
+                                        Boolean "Feature-337" {Price 114}
+                                        Boolean "Feature-532"
+                        String "Feature-333"
+                        Boolean "Feature-359"
+                                mandatory
+                                        Boolean "Feature-460" {Price 341}
+
+constraints
+        avg(Price) > 3253
+        "Feature-311" | "Feature-236" | "Feature-335" => "Feature-415" <=> "Feature-337" | !"Feature-407"
+        "Feature-524" | "Feature-17" => "Feature-200" | "Feature-487"
+        "Feature-40".Price + "Feature-331".Price - "Feature-464".Price + "Feature-60".Fun == "Feature-109".Price + "Feature-54".Fun
+        "Feature-279" <=> "Feature-518" & "Feature-408" <=> "Feature-500" | "Feature-469" | "Feature-159" & "Feature-439" & "Feature-292" => "Feature-121" | "Feature-339" <=> "Feature-331" & "Feature-382" <=> "Feature-497" <=> "Feature-47"
+        len("Feature-114") == 814
+        "Feature-453" | "Feature-398" <=> "Feature-294" & !"Feature-266"
+        "Feature-330" => "Feature-258" <=> "Feature-203" & "Feature-544" <=> "Feature-221" | "Feature-240" <=> "Feature-24" => "Feature-497" | "Feature-434" & "Feature-39" | "Feature-420" | "Feature-366" <=> !"Feature-2"
+        "Feature-393" => "Feature-427" | "Feature-413" | "Feature-208" => "Feature-37" | "Feature-419" => "Feature-490" <=> "Feature-343" => "Feature-137" | !"Feature-299"
+        "Feature-284" => "Feature-245"
+        "Feature-391" => "Feature-274" => "Feature-163" => "Feature-489" | "Feature-68" | "Feature-276" & !"Feature-445"
+        "Feature-416" <=> "Feature-129" => "Feature-283" <=> "Feature-518" | "Feature-106" | "Feature-35" & !"Feature-464"
+        "Feature-287" == '-1689268468'
+        "Feature-81" | !"Feature-209"
+        "Feature-66".Price - "Feature-155".Price + "Feature-311".Price * "Feature-106".Price == "Feature-143".Price / "Feature-528".Price / "Feature-511".Price - "Feature-488".Price
+        avg(Fun) > 370
+        avg(Price) > 4277
+        "Feature-54".Fun < "Feature-340".Price - "Feature-28".Price * "Feature-146".Price
+        "Feature-290".Price + "Feature-472".Price / "Feature-103".Price + "Feature-313".Price == "Feature-419".Price + "Feature-518".Price
+        "Feature-333" == '765378503'
+        "Feature-448" | "Feature-392" | "Feature-450" <=> "Feature-244" => "Feature-457" & "Feature-520" & "Feature-227" & "Feature-314" | "Feature-443" => "Feature-285" => "Feature-527" | "Feature-469" | "Feature-137"
+        "Feature-66" <=> "Feature-180" & !"Feature-294"
+        "Feature-457" | "Feature-20" <=> "Feature-492" <=> "Feature-60" | "Feature-451" => "Feature-76" & "Feature-506" => "Feature-307" & "Feature-483"
+        "Feature-204" | "Feature-435" => "Feature-489" | "Feature-171" => "Feature-59" => "Feature-355" => "Feature-548" <=> "Feature-261" | "Feature-469" => "Feature-8" <=> "Feature-379"
+        "Feature-386" => "Feature-304" <=> "Feature-406" => "Feature-261" <=> "Feature-285" <=> "Feature-123" & "Feature-95" <=> "Feature-470" | "Feature-69" | "Feature-44" => "Feature-40" | "Feature-292" & "Feature-431" | !"Feature-378"
+        "Feature-506".Price - "Feature-230".Price + "Feature-26".Price + "Feature-65".Price - "Feature-433".Price == "Feature-162".Price + "Feature-189".Price
+        "Feature-90" <=> "Feature-189" & "Feature-305" | "Feature-76" => "Feature-493" & "Feature-284" => "Feature-500" <=> "Feature-149" => !"Feature-224"
+        "Feature-198" == '1601079487'
+        "Feature-358" == '1751897462'
+        "Feature-364" <=> "Feature-547" & "Feature-490" & "Feature-69" => "Feature-340" <=> "Feature-34" <=> "Feature-427" & "Feature-448" & !"Feature-354"
+        "Feature-349" <=> "Feature-484" | "Feature-537" => "Feature-320" & !"Feature-56"
+        "Feature-230" => "Feature-293" <=> "Feature-118" <=> "Feature-283" <=> "Feature-507" & "Feature-69" => "Feature-42" => "Feature-544" | "Feature-423" & "Feature-41" <=> "Feature-265" | "Feature-2" <=> !"Feature-24"
+        len("Feature-54") == 472
+        "Feature-492" => "Feature-189" => "Feature-390" <=> "Feature-81" => "Feature-118" & "Feature-355" & "Feature-193" | "Feature-125" | "Feature-449" <=> "Feature-423" => "Feature-508"
+        avg(Price) > 3948
+        "Feature-73" => "Feature-59" <=> "Feature-457" & "Feature-112" <=> "Feature-419" & "Feature-436" | "Feature-215" <=> "Feature-171" & "Feature-125" | "Feature-79" => "Feature-77" | "Feature-37" => "Feature-26"
+        "Feature-383" | "Feature-262" & "Feature-202" | "Feature-415" <=> "Feature-350" & "Feature-355" => "Feature-74" <=> "Feature-507" <=> "Feature-123" => "Feature-397" | !"Feature-267"
+        "Feature-341" | "Feature-218" <=> "Feature-265" & "Feature-434" <=> "Feature-413" <=> "Feature-451" <=> "Feature-9" | !"Feature-279"
+        "Feature-463" | "Feature-391" => "Feature-387" & "Feature-66" <=> "Feature-406" | !"Feature-40"
+        "Feature-139" => "Feature-544" | "Feature-109" & "Feature-292" <=> "Feature-176" & "Feature-270" | "Feature-262" | "Feature-106" | "Feature-434" <=> "Feature-86" => "Feature-320" & "Feature-523" <=> "Feature-527" | !"Feature-199"
+        "Feature-486" <=> "Feature-328" & "Feature-285" <=> "Feature-329" => "Feature-219" & "Feature-167" => "Feature-89" => "Feature-469"
+        "Feature-233" & !"Feature-66"
+        "Feature-463".Price != "Feature-139".Price - "Feature-188".Fun / "Feature-108".Price + "Feature-307".Price
+        "Feature-78" == '-29675898'
+        "Feature-74" <=> "Feature-139" & "Feature-434" & "Feature-453" | "Feature-420" <=> "Feature-343" | "Feature-25" & "Feature-484"
+        len("Feature-136") == 413
+        "Feature-508" => "Feature-24"
+        "Feature-282" | "Feature-437" | !"Feature-193"
+        "Feature-119" <=> "Feature-489" => "Feature-351" <=> "Feature-171" => !"Feature-413"
+        "Feature-83" <=> "Feature-60" | "Feature-81" | "Feature-20" | "Feature-186" <=> "Feature-500" => "Feature-456"
+        "Feature-124" | "Feature-510" | "Feature-228" => "Feature-456" <=> "Feature-216" & "Feature-351"
+        "Feature-308" => "Feature-337" | "Feature-349" | "Feature-51" | "Feature-537" <=> "Feature-202" & "Feature-469" <=> "Feature-321" => "Feature-227" | "Feature-79" => "Feature-156" | "Feature-463"
+        "Feature-16" <=> "Feature-527" & "Feature-74" & "Feature-284" => "Feature-355" & "Feature-483" & "Feature-474" <=> "Feature-423" & "Feature-457" => "Feature-101" | !"Feature-276"
+        len("Feature-319") == 988
+        "Feature-343".Price * "Feature-445".Price + "Feature-89".Price - "Feature-425".Price / "Feature-145".Price > "Feature-420".Fun
+        "Feature-335" => "Feature-276" | "Feature-410" => "Feature-407" => "Feature-400" <=> "Feature-279" & "Feature-470" => !"Feature-17"
+        "Feature-251" => "Feature-159" | "Feature-209" <=> !"Feature-9"
+        "Feature-541" | "Feature-472" => !"Feature-26"
+        "Feature-281" => "Feature-271" | !"Feature-134"
+        len("Feature-280") == 878
+        "Feature-471" <=> "Feature-546" => "Feature-115" | "Feature-457" <=> "Feature-392" & !"Feature-366"
+        "Feature-472" => "Feature-295" & !"Feature-320"
+        "Feature-42" => "Feature-518" & "Feature-505" <=> "Feature-278" => "Feature-384" | "Feature-445" | "Feature-81" <=> "Feature-532" | "Feature-341" | "Feature-0" => "Feature-299" => !"Feature-416"
+        "Feature-469" <=> "Feature-30" | "Feature-267" & "Feature-299" <=> "Feature-439" => "Feature-274" & "Feature-159"
+        "Feature-343" => "Feature-451" | "Feature-425"
+        "Feature-17" => "Feature-483" | "Feature-119" => "Feature-96" & "Feature-86" | "Feature-92" <=> "Feature-177" | "Feature-203" & !"Feature-395"
+        "Feature-218" => "Feature-195"
+        "Feature-89" <=> "Feature-171" | "Feature-165" & "Feature-503" & "Feature-31" <=> "Feature-350" <=> "Feature-493" <=> "Feature-215" <=> "Feature-58" & "Feature-523" & !"Feature-146"
+        "Feature-195" => "Feature-73" => "Feature-41" | "Feature-277" <=> "Feature-137" <=> "Feature-435"
+        "Feature-56" | "Feature-205" => "Feature-69" <=> "Feature-321" <=> "Feature-428" & "Feature-189" => "Feature-527" & "Feature-484" | "Feature-209" & "Feature-445" => "Feature-190" <=> "Feature-123" => !"Feature-132"
+        "Feature-110".Fun * "Feature-146".Fun - "Feature-337".Price < "Feature-139".Price / "Feature-349".Price * "Feature-78".Price * "Feature-366".Price * "Feature-378".Price + "Feature-511".Price / "Feature-22".Price - "Feature-132".Price
+        "Feature-264" => "Feature-415" & "Feature-81" | "Feature-431" => "Feature-56" & "Feature-74" => "Feature-34" & "Feature-4" & "Feature-500" | "Feature-503" => "Feature-416"
+        len("Feature-0") == 530
+        len("Feature-181") == 434
+        "Feature-366" | "Feature-475" <=> "Feature-264" & "Feature-66" & "Feature-4" | "Feature-413"

--- a/test_resources/parsing/language_level/all.uvl
+++ b/test_resources/parsing/language_level/all.uvl
@@ -1,0 +1,18 @@
+include
+    Boolean.*
+    Arithmetic.aggregate-function
+    Type
+
+features
+    A
+        or
+            B {Price 2}
+            C {Price 4}
+                [2..3]
+                    C1
+                    C2
+                    C3
+            Integer D
+        
+constraints
+    sum(Price) > 3

--- a/test_resources/parsing/language_level/arithmetic.uvl
+++ b/test_resources/parsing/language_level/arithmetic.uvl
@@ -1,0 +1,12 @@
+include
+    Arithmetic
+
+features
+    A
+        or 
+            B {Price 3}
+            C {Price 5}
+
+
+constraints
+    B.Price + C.Price == 8

--- a/test_resources/parsing/language_level/boolean.uvl
+++ b/test_resources/parsing/language_level/boolean.uvl
@@ -1,0 +1,8 @@
+include
+    Boolean
+
+features
+    A
+        or
+            B
+            C

--- a/test_resources/parsing/language_level/type.uvl
+++ b/test_resources/parsing/language_level/type.uvl
@@ -1,0 +1,8 @@
+include
+    Type
+
+features
+    Real A
+        or
+            Integer B
+            String C

--- a/test_resources/parsing/syntax/brackets.uvl
+++ b/test_resources/parsing/syntax/brackets.uvl
@@ -1,0 +1,11 @@
+features
+    "Brackets()[]{}"
+        optional
+            String "B()"
+            "C()" {Function 'Fun()'}
+            String "B[]"
+            "C[]" {Function 'Fun[]'}
+            String "B{}"
+            "C{}" {Function 'Fun{}'}
+
+    

--- a/test_resources/parsing/syntax/comments.uvl
+++ b/test_resources/parsing/syntax/comments.uvl
@@ -1,0 +1,16 @@
+// This is a comment
+features // This is a comment
+    A // This is a comment
+        or // This is a comment
+    // This is a comment
+            B {Price 2, Fun 12} // This is a comment
+            C {Price 7, Fun 6} // This is a comment
+            D {Price 5, Fun 8} // This is a comment
+constraints // This is a comment
+    // This is a comment
+    B.Fun + C.Fun - B.Price == 16
+// This is a comment
+    B.Fun + (C.Fun - B.Price) == 16 // This is a comment
+    B.Fun + C.Fun * B.Price == 20 // This is a comment
+    // This is a comment
+// This is a comment

--- a/test_resources/parsing/syntax/dash.uvl
+++ b/test_resources/parsing/syntax/dash.uvl
@@ -1,0 +1,7 @@
+features
+     Root
+       optional
+           Integer A
+           Integer B
+constraints
+     A-B == 0

--- a/test_resources/parsing/type_level/nested/string-attributes-external.uvl
+++ b/test_resources/parsing/type_level/nested/string-attributes-external.uvl
@@ -1,0 +1,6 @@
+features
+    E
+        optional
+            F {Fun 'Yes This is  x Test', Nxme 'B // Cxn I do x comment in here?', Pxckxge {Nxme 'P', Content 'Even more fun'}, Price 5}
+            G {Fun 'mxybe', Nxme 'C'}
+            H {Fun 'This is x test with x newline in the string', Nxme 'D'}

--- a/test_resources/parsing/type_level/string-attributes.uvl
+++ b/test_resources/parsing/type_level/string-attributes.uvl
@@ -1,0 +1,12 @@
+imports
+  nested."string-attributes-external" as external
+
+features
+    A
+        optional
+            B {Fun 'Yes. This is  a Test', Name 'B // Cxn I do a comment in here?', Package {Name 'P', Content 'Even more fun'}, Price 5}
+            C {Fun 'maybe', Name 'C'}
+            D {Fun 'This is a test with a newline in the string', Name 'D'}
+            external.E
+            F {Fun 'This string external.G See?', Name 'F'}
+            G {Fun 'Another.test.with.multiple.dots', Name 'G'}

--- a/test_resources/parsing/type_level/string-constraints.uvl
+++ b/test_resources/parsing/type_level/string-constraints.uvl
@@ -1,0 +1,12 @@
+features
+    A
+        optional
+            String C
+            String D
+
+constraints
+    len(C) == 3
+    D == C
+    C == 'Fun'
+    'Fun' == D
+    A


### PR DESCRIPTION
Add test models in the uvl-models repo. Therefore thy can be used in the java-fm-metamodel and the uvl-parser without being duplicated.